### PR TITLE
fix missing interval id in retry metadata on shutdown

### DIFF
--- a/loadtester/loadtest.go
+++ b/loadtester/loadtest.go
@@ -703,6 +703,7 @@ func (lt *Loadtest) run(ctx context.Context, shutdownErrResp *error) error {
 						lt.resultWaitGroup.Add(1)
 						lt.resultsChan <- taskResult{
 							Meta: taskMeta{
+								IntervalID: intervalID,
 								Lag: lag,
 							},
 						}


### PR DESCRIPTION
This is why tests are warranted. Definitely some copy pasta that has gone on and improvements in some pasta sauce but not in others.