### PR TITLE
fix: make sample size reporting in metrics more congruent/deterministic

### DIFF
--- a/loadtester/gen_strategies.go
+++ b/loadtester/gen_strategies.go
@@ -1088,7 +1088,13 @@ func (lt *Loadtest) run_retriesEnabled_maxTasksGTZero_metricsEnabled(ctx context
 						lt.intervalTasksSema.Release(int64(numNewTasks - taskBufSize))
 					}
 
-					lt.resultWaitGroup.Add(taskBufSize)
+					lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
+					lt.resultsChan <- taskResult{
+						Meta: taskMeta{
+							IntervalID: intervalID,
+							SampleSize: taskBufSize,
+						},
+					}
 
 					meta.IntervalID = intervalID
 
@@ -1533,7 +1539,13 @@ func (lt *Loadtest) run_retriesEnabled_maxTasksGTZero_metricsEnabled(ctx context
 			lt.intervalTasksSema.Release(int64(numNewTasks - taskBufSize))
 		}
 
-		lt.resultWaitGroup.Add(taskBufSize)
+		lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
+		lt.resultsChan <- taskResult{
+			Meta: taskMeta{
+				IntervalID: intervalID,
+				SampleSize: taskBufSize,
+			},
+		}
 
 		meta.IntervalID = intervalID
 
@@ -1849,7 +1861,13 @@ func (lt *Loadtest) run_retriesEnabled_maxTasksGTZero_metricsDisabled(ctx contex
 						lt.intervalTasksSema.Release(int64(numNewTasks - taskBufSize))
 					}
 
-					lt.resultWaitGroup.Add(taskBufSize)
+					lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
+					lt.resultsChan <- taskResult{
+						Meta: taskMeta{
+							IntervalID: intervalID,
+							SampleSize: taskBufSize,
+						},
+					}
 
 					meta.IntervalID = intervalID
 
@@ -2268,7 +2286,13 @@ func (lt *Loadtest) run_retriesEnabled_maxTasksGTZero_metricsDisabled(ctx contex
 			lt.intervalTasksSema.Release(int64(numNewTasks - taskBufSize))
 		}
 
-		lt.resultWaitGroup.Add(taskBufSize)
+		lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
+		lt.resultsChan <- taskResult{
+			Meta: taskMeta{
+				IntervalID: intervalID,
+				SampleSize: taskBufSize,
+			},
+		}
 
 		meta.IntervalID = intervalID
 
@@ -2562,7 +2586,13 @@ func (lt *Loadtest) run_retriesEnabled_maxTasksNotGTZero_metricsEnabled(ctx cont
 						lt.intervalTasksSema.Release(int64(numNewTasks - taskBufSize))
 					}
 
-					lt.resultWaitGroup.Add(taskBufSize)
+					lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
+					lt.resultsChan <- taskResult{
+						Meta: taskMeta{
+							IntervalID: intervalID,
+							SampleSize: taskBufSize,
+						},
+					}
 
 					meta.IntervalID = intervalID
 
@@ -2992,7 +3022,13 @@ func (lt *Loadtest) run_retriesEnabled_maxTasksNotGTZero_metricsEnabled(ctx cont
 			lt.intervalTasksSema.Release(int64(numNewTasks - taskBufSize))
 		}
 
-		lt.resultWaitGroup.Add(taskBufSize)
+		lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
+		lt.resultsChan <- taskResult{
+			Meta: taskMeta{
+				IntervalID: intervalID,
+				SampleSize: taskBufSize,
+			},
+		}
 
 		meta.IntervalID = intervalID
 
@@ -3270,7 +3306,13 @@ func (lt *Loadtest) run_retriesEnabled_maxTasksNotGTZero_metricsDisabled(ctx con
 						lt.intervalTasksSema.Release(int64(numNewTasks - taskBufSize))
 					}
 
-					lt.resultWaitGroup.Add(taskBufSize)
+					lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
+					lt.resultsChan <- taskResult{
+						Meta: taskMeta{
+							IntervalID: intervalID,
+							SampleSize: taskBufSize,
+						},
+					}
 
 					meta.IntervalID = intervalID
 
@@ -3674,7 +3716,13 @@ func (lt *Loadtest) run_retriesEnabled_maxTasksNotGTZero_metricsDisabled(ctx con
 			lt.intervalTasksSema.Release(int64(numNewTasks - taskBufSize))
 		}
 
-		lt.resultWaitGroup.Add(taskBufSize)
+		lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
+		lt.resultsChan <- taskResult{
+			Meta: taskMeta{
+				IntervalID: intervalID,
+				SampleSize: taskBufSize,
+			},
+		}
 
 		meta.IntervalID = intervalID
 
@@ -4161,7 +4209,13 @@ func (lt *Loadtest) run_retriesDisabled_maxTasksGTZero_metricsEnabled(ctx contex
 			return nil
 		}
 
-		lt.resultWaitGroup.Add(taskBufSize)
+		lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
+		lt.resultsChan <- taskResult{
+			Meta: taskMeta{
+				IntervalID: intervalID,
+				SampleSize: taskBufSize,
+			},
+		}
 
 		meta.IntervalID = intervalID
 
@@ -4620,7 +4674,13 @@ func (lt *Loadtest) run_retriesDisabled_maxTasksGTZero_metricsDisabled(ctx conte
 			return nil
 		}
 
-		lt.resultWaitGroup.Add(taskBufSize)
+		lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
+		lt.resultsChan <- taskResult{
+			Meta: taskMeta{
+				IntervalID: intervalID,
+				SampleSize: taskBufSize,
+			},
+		}
 
 		meta.IntervalID = intervalID
 
@@ -5090,7 +5150,13 @@ func (lt *Loadtest) run_retriesDisabled_maxTasksNotGTZero_metricsEnabled(ctx con
 			return nil
 		}
 
-		lt.resultWaitGroup.Add(taskBufSize)
+		lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
+		lt.resultsChan <- taskResult{
+			Meta: taskMeta{
+				IntervalID: intervalID,
+				SampleSize: taskBufSize,
+			},
+		}
 
 		meta.IntervalID = intervalID
 
@@ -5532,7 +5598,13 @@ func (lt *Loadtest) run_retriesDisabled_maxTasksNotGTZero_metricsDisabled(ctx co
 			return nil
 		}
 
-		lt.resultWaitGroup.Add(taskBufSize)
+		lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
+		lt.resultsChan <- taskResult{
+			Meta: taskMeta{
+				IntervalID: intervalID,
+				SampleSize: taskBufSize,
+			},
+		}
 
 		meta.IntervalID = intervalID
 
@@ -6555,1441 +6627,1729 @@ func (lt *Loadtest) writeOutputCsvRow_retryDisabled_maxTasksNotGTZero_percentile
 	}
 }
 
-func (lt *Loadtest) resultsHandler_retryEnabled_maxTasksGTZero_percentileEnabled_varianceEnabled() {
+func (lt *Loadtest) resultsHandler_retryEnabled_maxTasksGTZero_percentileEnabled_varianceEnabled() func() {
 
-	cd := &lt.csvData
-	var mr metricRecord_retryEnabled_maxTasksGTZero_percentileEnabled_varianceEnabled
-	mr.latencies = lt.latencies
-	mr.reset()
+	// construct ring buffer of sample sizes (ss)
+	ssSize := lt.maxLiveSamples
+	ss := make([]int, ssSize)
+	var ssNextWriteIdx int
+	var ssReadIdx int
 
-	var writeRow func()
-	{
-		f := lt.writeOutputCsvRow_retryEnabled_maxTasksGTZero_percentileEnabled_varianceEnabled()
-		writeRow = func() {
+	return func() {
+		cd := &lt.csvData
+		var mr metricRecord_retryEnabled_maxTasksGTZero_percentileEnabled_varianceEnabled
+		mr.latencies = lt.latencies
+		mr.reset()
 
-			mr.totalNumTasks += mr.numTasks
+		var writeRow func()
+		{
+			f := lt.writeOutputCsvRow_retryEnabled_maxTasksGTZero_percentileEnabled_varianceEnabled()
+			writeRow = func() {
 
-			f(mr)
-		}
-	}
+				mr.totalNumTasks += mr.numTasks
 
-	cd.flushDeadline = time.Now().Add(cd.flushInterval)
-
-	for {
-		tr, ok := <-lt.resultsChan
-		if !ok {
-			if cd.writeErr == nil && mr.numTasks > 0 {
-				writeRow()
+				f(mr)
 			}
-			return
 		}
 
-		lt.resultWaitGroup.Done()
+		cd.flushDeadline = time.Now().Add(cd.flushInterval)
 
-		if cd.writeErr != nil {
-			continue
-		}
-
-		if tr.taskResultFlags.isZero() {
-
-			mr.sumLag += tr.Meta.Lag
-
-			continue
-		}
-
-		if mr.intervalID.Before(tr.Meta.IntervalID) {
-			mr.intervalID = tr.Meta.IntervalID
-			mr.numIntervalTasks = tr.Meta.NumIntervalTasks
-			mr.lag = tr.Meta.Lag
-		}
-
-		if mr.minQueueDuration > tr.QueueDuration {
-			mr.minQueueDuration = tr.QueueDuration
-		}
-
-		if mr.minTaskDuration > tr.TaskDuration {
-			mr.minTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxTaskDuration < tr.TaskDuration {
-			mr.maxTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxQueueDuration < tr.QueueDuration {
-			mr.maxQueueDuration = tr.QueueDuration
-		}
-
-		mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
-		mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
-		mr.numPass += int(tr.Passed)
-		mr.numFail += int(tr.Errored)
-		mr.numPanic += int(tr.Panicked)
-		mr.numRetry += int(tr.RetryQueued)
-
-		mr.numTasks++
-
-		mr.welfords.queue.Update(mr.numTasks, float64(tr.QueueDuration))
-		mr.welfords.task.Update(mr.numTasks, float64(tr.TaskDuration))
-
-		mr.latencies.queue.add(tr.QueueDuration)
-		mr.latencies.task.add(tr.TaskDuration)
-
-		if mr.numTasks >= mr.numIntervalTasks {
-
-			writeRow()
-			mr.reset()
-
-			if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
-				cd.writer.Flush()
-				if err := cd.writer.Error(); err != nil {
-					cd.setErr(err) // sets error state in multiple goroutine safe way
+		for {
+			tr, ok := <-lt.resultsChan
+			if !ok {
+				if cd.writeErr == nil && mr.numTasks > 0 {
+					writeRow()
 				}
-				cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				return
+			}
+
+			lt.resultWaitGroup.Done()
+
+			if cd.writeErr != nil {
+				continue
+			}
+
+			if tr.taskResultFlags.isZero() {
+
+				mr.sumLag += tr.Meta.Lag
+
+				if tr.Meta.SampleSize > 0 {
+					ss[ssNextWriteIdx] = tr.Meta.SampleSize
+
+					// advance write pointer forward
+					ssNextWriteIdx = (ssNextWriteIdx + 1) % ssSize
+				}
+
+				continue
+			}
+
+			if mr.intervalID.Before(tr.Meta.IntervalID) {
+				mr.intervalID = tr.Meta.IntervalID
+				mr.numIntervalTasks = tr.Meta.NumIntervalTasks
+				mr.lag = tr.Meta.Lag
+			}
+
+			if mr.minQueueDuration > tr.QueueDuration {
+				mr.minQueueDuration = tr.QueueDuration
+			}
+
+			if mr.minTaskDuration > tr.TaskDuration {
+				mr.minTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxTaskDuration < tr.TaskDuration {
+				mr.maxTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxQueueDuration < tr.QueueDuration {
+				mr.maxQueueDuration = tr.QueueDuration
+			}
+
+			mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
+			mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
+			mr.numPass += int(tr.Passed)
+			mr.numFail += int(tr.Errored)
+			mr.numPanic += int(tr.Panicked)
+			mr.numRetry += int(tr.RetryQueued)
+
+			mr.numTasks++
+
+			mr.welfords.queue.Update(mr.numTasks, float64(tr.QueueDuration))
+			mr.welfords.task.Update(mr.numTasks, float64(tr.TaskDuration))
+
+			mr.latencies.queue.add(tr.QueueDuration)
+			mr.latencies.task.add(tr.TaskDuration)
+
+			if mr.numTasks >= ss[ssReadIdx] {
+
+				writeRow()
+				mr.reset()
+
+				// advance read pointer forward
+				ssReadIdx = (ssReadIdx + 1) % ssSize
+
+				if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
+					cd.writer.Flush()
+					if err := cd.writer.Error(); err != nil {
+						cd.setErr(err) // sets error state in multiple goroutine safe way
+					}
+					cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				}
 			}
 		}
 	}
 }
 
-func (lt *Loadtest) resultsHandler_retryEnabled_maxTasksGTZero_percentileEnabled_varianceDisabled() {
+func (lt *Loadtest) resultsHandler_retryEnabled_maxTasksGTZero_percentileEnabled_varianceDisabled() func() {
 
-	cd := &lt.csvData
-	var mr metricRecord_retryEnabled_maxTasksGTZero_percentileEnabled_varianceDisabled
-	mr.latencies = lt.latencies
-	mr.reset()
+	// construct ring buffer of sample sizes (ss)
+	ssSize := lt.maxLiveSamples
+	ss := make([]int, ssSize)
+	var ssNextWriteIdx int
+	var ssReadIdx int
 
-	var writeRow func()
-	{
-		f := lt.writeOutputCsvRow_retryEnabled_maxTasksGTZero_percentileEnabled_varianceDisabled()
-		writeRow = func() {
+	return func() {
+		cd := &lt.csvData
+		var mr metricRecord_retryEnabled_maxTasksGTZero_percentileEnabled_varianceDisabled
+		mr.latencies = lt.latencies
+		mr.reset()
 
-			mr.totalNumTasks += mr.numTasks
+		var writeRow func()
+		{
+			f := lt.writeOutputCsvRow_retryEnabled_maxTasksGTZero_percentileEnabled_varianceDisabled()
+			writeRow = func() {
 
-			f(mr)
-		}
-	}
+				mr.totalNumTasks += mr.numTasks
 
-	cd.flushDeadline = time.Now().Add(cd.flushInterval)
-
-	for {
-		tr, ok := <-lt.resultsChan
-		if !ok {
-			if cd.writeErr == nil && mr.numTasks > 0 {
-				writeRow()
+				f(mr)
 			}
-			return
 		}
 
-		lt.resultWaitGroup.Done()
+		cd.flushDeadline = time.Now().Add(cd.flushInterval)
 
-		if cd.writeErr != nil {
-			continue
-		}
-
-		if tr.taskResultFlags.isZero() {
-
-			mr.sumLag += tr.Meta.Lag
-
-			continue
-		}
-
-		if mr.intervalID.Before(tr.Meta.IntervalID) {
-			mr.intervalID = tr.Meta.IntervalID
-			mr.numIntervalTasks = tr.Meta.NumIntervalTasks
-			mr.lag = tr.Meta.Lag
-		}
-
-		if mr.minQueueDuration > tr.QueueDuration {
-			mr.minQueueDuration = tr.QueueDuration
-		}
-
-		if mr.minTaskDuration > tr.TaskDuration {
-			mr.minTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxTaskDuration < tr.TaskDuration {
-			mr.maxTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxQueueDuration < tr.QueueDuration {
-			mr.maxQueueDuration = tr.QueueDuration
-		}
-
-		mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
-		mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
-		mr.numPass += int(tr.Passed)
-		mr.numFail += int(tr.Errored)
-		mr.numPanic += int(tr.Panicked)
-		mr.numRetry += int(tr.RetryQueued)
-
-		mr.numTasks++
-
-		mr.latencies.queue.add(tr.QueueDuration)
-		mr.latencies.task.add(tr.TaskDuration)
-
-		if mr.numTasks >= mr.numIntervalTasks {
-
-			writeRow()
-			mr.reset()
-
-			if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
-				cd.writer.Flush()
-				if err := cd.writer.Error(); err != nil {
-					cd.setErr(err) // sets error state in multiple goroutine safe way
+		for {
+			tr, ok := <-lt.resultsChan
+			if !ok {
+				if cd.writeErr == nil && mr.numTasks > 0 {
+					writeRow()
 				}
-				cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				return
+			}
+
+			lt.resultWaitGroup.Done()
+
+			if cd.writeErr != nil {
+				continue
+			}
+
+			if tr.taskResultFlags.isZero() {
+
+				mr.sumLag += tr.Meta.Lag
+
+				if tr.Meta.SampleSize > 0 {
+					ss[ssNextWriteIdx] = tr.Meta.SampleSize
+
+					// advance write pointer forward
+					ssNextWriteIdx = (ssNextWriteIdx + 1) % ssSize
+				}
+
+				continue
+			}
+
+			if mr.intervalID.Before(tr.Meta.IntervalID) {
+				mr.intervalID = tr.Meta.IntervalID
+				mr.numIntervalTasks = tr.Meta.NumIntervalTasks
+				mr.lag = tr.Meta.Lag
+			}
+
+			if mr.minQueueDuration > tr.QueueDuration {
+				mr.minQueueDuration = tr.QueueDuration
+			}
+
+			if mr.minTaskDuration > tr.TaskDuration {
+				mr.minTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxTaskDuration < tr.TaskDuration {
+				mr.maxTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxQueueDuration < tr.QueueDuration {
+				mr.maxQueueDuration = tr.QueueDuration
+			}
+
+			mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
+			mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
+			mr.numPass += int(tr.Passed)
+			mr.numFail += int(tr.Errored)
+			mr.numPanic += int(tr.Panicked)
+			mr.numRetry += int(tr.RetryQueued)
+
+			mr.numTasks++
+
+			mr.latencies.queue.add(tr.QueueDuration)
+			mr.latencies.task.add(tr.TaskDuration)
+
+			if mr.numTasks >= ss[ssReadIdx] {
+
+				writeRow()
+				mr.reset()
+
+				// advance read pointer forward
+				ssReadIdx = (ssReadIdx + 1) % ssSize
+
+				if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
+					cd.writer.Flush()
+					if err := cd.writer.Error(); err != nil {
+						cd.setErr(err) // sets error state in multiple goroutine safe way
+					}
+					cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				}
 			}
 		}
 	}
 }
 
-func (lt *Loadtest) resultsHandler_retryEnabled_maxTasksGTZero_percentileDisabled_varianceEnabled() {
+func (lt *Loadtest) resultsHandler_retryEnabled_maxTasksGTZero_percentileDisabled_varianceEnabled() func() {
 
-	cd := &lt.csvData
-	var mr metricRecord_retryEnabled_maxTasksGTZero_percentileDisabled_varianceEnabled
-	mr.reset()
+	// construct ring buffer of sample sizes (ss)
+	ssSize := lt.maxLiveSamples
+	ss := make([]int, ssSize)
+	var ssNextWriteIdx int
+	var ssReadIdx int
 
-	var writeRow func()
-	{
-		f := lt.writeOutputCsvRow_retryEnabled_maxTasksGTZero_percentileDisabled_varianceEnabled()
-		writeRow = func() {
+	return func() {
+		cd := &lt.csvData
+		var mr metricRecord_retryEnabled_maxTasksGTZero_percentileDisabled_varianceEnabled
+		mr.reset()
 
-			mr.totalNumTasks += mr.numTasks
+		var writeRow func()
+		{
+			f := lt.writeOutputCsvRow_retryEnabled_maxTasksGTZero_percentileDisabled_varianceEnabled()
+			writeRow = func() {
 
-			f(mr)
-		}
-	}
+				mr.totalNumTasks += mr.numTasks
 
-	cd.flushDeadline = time.Now().Add(cd.flushInterval)
-
-	for {
-		tr, ok := <-lt.resultsChan
-		if !ok {
-			if cd.writeErr == nil && mr.numTasks > 0 {
-				writeRow()
+				f(mr)
 			}
-			return
 		}
 
-		lt.resultWaitGroup.Done()
+		cd.flushDeadline = time.Now().Add(cd.flushInterval)
 
-		if cd.writeErr != nil {
-			continue
-		}
-
-		if tr.taskResultFlags.isZero() {
-
-			mr.sumLag += tr.Meta.Lag
-
-			continue
-		}
-
-		if mr.intervalID.Before(tr.Meta.IntervalID) {
-			mr.intervalID = tr.Meta.IntervalID
-			mr.numIntervalTasks = tr.Meta.NumIntervalTasks
-			mr.lag = tr.Meta.Lag
-		}
-
-		if mr.minQueueDuration > tr.QueueDuration {
-			mr.minQueueDuration = tr.QueueDuration
-		}
-
-		if mr.minTaskDuration > tr.TaskDuration {
-			mr.minTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxTaskDuration < tr.TaskDuration {
-			mr.maxTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxQueueDuration < tr.QueueDuration {
-			mr.maxQueueDuration = tr.QueueDuration
-		}
-
-		mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
-		mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
-		mr.numPass += int(tr.Passed)
-		mr.numFail += int(tr.Errored)
-		mr.numPanic += int(tr.Panicked)
-		mr.numRetry += int(tr.RetryQueued)
-
-		mr.numTasks++
-
-		mr.welfords.queue.Update(mr.numTasks, float64(tr.QueueDuration))
-		mr.welfords.task.Update(mr.numTasks, float64(tr.TaskDuration))
-
-		if mr.numTasks >= mr.numIntervalTasks {
-
-			writeRow()
-			mr.reset()
-
-			if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
-				cd.writer.Flush()
-				if err := cd.writer.Error(); err != nil {
-					cd.setErr(err) // sets error state in multiple goroutine safe way
+		for {
+			tr, ok := <-lt.resultsChan
+			if !ok {
+				if cd.writeErr == nil && mr.numTasks > 0 {
+					writeRow()
 				}
-				cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				return
+			}
+
+			lt.resultWaitGroup.Done()
+
+			if cd.writeErr != nil {
+				continue
+			}
+
+			if tr.taskResultFlags.isZero() {
+
+				mr.sumLag += tr.Meta.Lag
+
+				if tr.Meta.SampleSize > 0 {
+					ss[ssNextWriteIdx] = tr.Meta.SampleSize
+
+					// advance write pointer forward
+					ssNextWriteIdx = (ssNextWriteIdx + 1) % ssSize
+				}
+
+				continue
+			}
+
+			if mr.intervalID.Before(tr.Meta.IntervalID) {
+				mr.intervalID = tr.Meta.IntervalID
+				mr.numIntervalTasks = tr.Meta.NumIntervalTasks
+				mr.lag = tr.Meta.Lag
+			}
+
+			if mr.minQueueDuration > tr.QueueDuration {
+				mr.minQueueDuration = tr.QueueDuration
+			}
+
+			if mr.minTaskDuration > tr.TaskDuration {
+				mr.minTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxTaskDuration < tr.TaskDuration {
+				mr.maxTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxQueueDuration < tr.QueueDuration {
+				mr.maxQueueDuration = tr.QueueDuration
+			}
+
+			mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
+			mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
+			mr.numPass += int(tr.Passed)
+			mr.numFail += int(tr.Errored)
+			mr.numPanic += int(tr.Panicked)
+			mr.numRetry += int(tr.RetryQueued)
+
+			mr.numTasks++
+
+			mr.welfords.queue.Update(mr.numTasks, float64(tr.QueueDuration))
+			mr.welfords.task.Update(mr.numTasks, float64(tr.TaskDuration))
+
+			if mr.numTasks >= ss[ssReadIdx] {
+
+				writeRow()
+				mr.reset()
+
+				// advance read pointer forward
+				ssReadIdx = (ssReadIdx + 1) % ssSize
+
+				if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
+					cd.writer.Flush()
+					if err := cd.writer.Error(); err != nil {
+						cd.setErr(err) // sets error state in multiple goroutine safe way
+					}
+					cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				}
 			}
 		}
 	}
 }
 
-func (lt *Loadtest) resultsHandler_retryEnabled_maxTasksGTZero_percentileDisabled_varianceDisabled() {
+func (lt *Loadtest) resultsHandler_retryEnabled_maxTasksGTZero_percentileDisabled_varianceDisabled() func() {
 
-	cd := &lt.csvData
-	var mr metricRecord_retryEnabled_maxTasksGTZero_percentileDisabled_varianceDisabled
-	mr.reset()
+	// construct ring buffer of sample sizes (ss)
+	ssSize := lt.maxLiveSamples
+	ss := make([]int, ssSize)
+	var ssNextWriteIdx int
+	var ssReadIdx int
 
-	var writeRow func()
-	{
-		f := lt.writeOutputCsvRow_retryEnabled_maxTasksGTZero_percentileDisabled_varianceDisabled()
-		writeRow = func() {
+	return func() {
+		cd := &lt.csvData
+		var mr metricRecord_retryEnabled_maxTasksGTZero_percentileDisabled_varianceDisabled
+		mr.reset()
 
-			mr.totalNumTasks += mr.numTasks
+		var writeRow func()
+		{
+			f := lt.writeOutputCsvRow_retryEnabled_maxTasksGTZero_percentileDisabled_varianceDisabled()
+			writeRow = func() {
 
-			f(mr)
-		}
-	}
+				mr.totalNumTasks += mr.numTasks
 
-	cd.flushDeadline = time.Now().Add(cd.flushInterval)
-
-	for {
-		tr, ok := <-lt.resultsChan
-		if !ok {
-			if cd.writeErr == nil && mr.numTasks > 0 {
-				writeRow()
+				f(mr)
 			}
-			return
 		}
 
-		lt.resultWaitGroup.Done()
+		cd.flushDeadline = time.Now().Add(cd.flushInterval)
 
-		if cd.writeErr != nil {
-			continue
-		}
-
-		if tr.taskResultFlags.isZero() {
-
-			mr.sumLag += tr.Meta.Lag
-
-			continue
-		}
-
-		if mr.intervalID.Before(tr.Meta.IntervalID) {
-			mr.intervalID = tr.Meta.IntervalID
-			mr.numIntervalTasks = tr.Meta.NumIntervalTasks
-			mr.lag = tr.Meta.Lag
-		}
-
-		if mr.minQueueDuration > tr.QueueDuration {
-			mr.minQueueDuration = tr.QueueDuration
-		}
-
-		if mr.minTaskDuration > tr.TaskDuration {
-			mr.minTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxTaskDuration < tr.TaskDuration {
-			mr.maxTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxQueueDuration < tr.QueueDuration {
-			mr.maxQueueDuration = tr.QueueDuration
-		}
-
-		mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
-		mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
-		mr.numPass += int(tr.Passed)
-		mr.numFail += int(tr.Errored)
-		mr.numPanic += int(tr.Panicked)
-		mr.numRetry += int(tr.RetryQueued)
-
-		mr.numTasks++
-
-		if mr.numTasks >= mr.numIntervalTasks {
-
-			writeRow()
-			mr.reset()
-
-			if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
-				cd.writer.Flush()
-				if err := cd.writer.Error(); err != nil {
-					cd.setErr(err) // sets error state in multiple goroutine safe way
+		for {
+			tr, ok := <-lt.resultsChan
+			if !ok {
+				if cd.writeErr == nil && mr.numTasks > 0 {
+					writeRow()
 				}
-				cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				return
+			}
+
+			lt.resultWaitGroup.Done()
+
+			if cd.writeErr != nil {
+				continue
+			}
+
+			if tr.taskResultFlags.isZero() {
+
+				mr.sumLag += tr.Meta.Lag
+
+				if tr.Meta.SampleSize > 0 {
+					ss[ssNextWriteIdx] = tr.Meta.SampleSize
+
+					// advance write pointer forward
+					ssNextWriteIdx = (ssNextWriteIdx + 1) % ssSize
+				}
+
+				continue
+			}
+
+			if mr.intervalID.Before(tr.Meta.IntervalID) {
+				mr.intervalID = tr.Meta.IntervalID
+				mr.numIntervalTasks = tr.Meta.NumIntervalTasks
+				mr.lag = tr.Meta.Lag
+			}
+
+			if mr.minQueueDuration > tr.QueueDuration {
+				mr.minQueueDuration = tr.QueueDuration
+			}
+
+			if mr.minTaskDuration > tr.TaskDuration {
+				mr.minTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxTaskDuration < tr.TaskDuration {
+				mr.maxTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxQueueDuration < tr.QueueDuration {
+				mr.maxQueueDuration = tr.QueueDuration
+			}
+
+			mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
+			mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
+			mr.numPass += int(tr.Passed)
+			mr.numFail += int(tr.Errored)
+			mr.numPanic += int(tr.Panicked)
+			mr.numRetry += int(tr.RetryQueued)
+
+			mr.numTasks++
+
+			if mr.numTasks >= ss[ssReadIdx] {
+
+				writeRow()
+				mr.reset()
+
+				// advance read pointer forward
+				ssReadIdx = (ssReadIdx + 1) % ssSize
+
+				if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
+					cd.writer.Flush()
+					if err := cd.writer.Error(); err != nil {
+						cd.setErr(err) // sets error state in multiple goroutine safe way
+					}
+					cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				}
 			}
 		}
 	}
 }
 
-func (lt *Loadtest) resultsHandler_retryEnabled_maxTasksNotGTZero_percentileEnabled_varianceEnabled() {
+func (lt *Loadtest) resultsHandler_retryEnabled_maxTasksNotGTZero_percentileEnabled_varianceEnabled() func() {
 
-	cd := &lt.csvData
-	var mr metricRecord_retryEnabled_maxTasksNotGTZero_percentileEnabled_varianceEnabled
-	mr.latencies = lt.latencies
-	mr.reset()
+	// construct ring buffer of sample sizes (ss)
+	ssSize := lt.maxLiveSamples
+	ss := make([]int, ssSize)
+	var ssNextWriteIdx int
+	var ssReadIdx int
 
-	var writeRow func()
-	{
-		f := lt.writeOutputCsvRow_retryEnabled_maxTasksNotGTZero_percentileEnabled_varianceEnabled()
-		writeRow = func() {
+	return func() {
+		cd := &lt.csvData
+		var mr metricRecord_retryEnabled_maxTasksNotGTZero_percentileEnabled_varianceEnabled
+		mr.latencies = lt.latencies
+		mr.reset()
 
-			f(mr)
-		}
-	}
+		var writeRow func()
+		{
+			f := lt.writeOutputCsvRow_retryEnabled_maxTasksNotGTZero_percentileEnabled_varianceEnabled()
+			writeRow = func() {
 
-	cd.flushDeadline = time.Now().Add(cd.flushInterval)
-
-	for {
-		tr, ok := <-lt.resultsChan
-		if !ok {
-			if cd.writeErr == nil && mr.numTasks > 0 {
-				writeRow()
+				f(mr)
 			}
-			return
 		}
 
-		lt.resultWaitGroup.Done()
+		cd.flushDeadline = time.Now().Add(cd.flushInterval)
 
-		if cd.writeErr != nil {
-			continue
-		}
-
-		if tr.taskResultFlags.isZero() {
-
-			mr.sumLag += tr.Meta.Lag
-
-			continue
-		}
-
-		if mr.intervalID.Before(tr.Meta.IntervalID) {
-			mr.intervalID = tr.Meta.IntervalID
-			mr.numIntervalTasks = tr.Meta.NumIntervalTasks
-			mr.lag = tr.Meta.Lag
-		}
-
-		if mr.minQueueDuration > tr.QueueDuration {
-			mr.minQueueDuration = tr.QueueDuration
-		}
-
-		if mr.minTaskDuration > tr.TaskDuration {
-			mr.minTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxTaskDuration < tr.TaskDuration {
-			mr.maxTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxQueueDuration < tr.QueueDuration {
-			mr.maxQueueDuration = tr.QueueDuration
-		}
-
-		mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
-		mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
-		mr.numPass += int(tr.Passed)
-		mr.numFail += int(tr.Errored)
-		mr.numPanic += int(tr.Panicked)
-		mr.numRetry += int(tr.RetryQueued)
-
-		mr.numTasks++
-
-		mr.welfords.queue.Update(mr.numTasks, float64(tr.QueueDuration))
-		mr.welfords.task.Update(mr.numTasks, float64(tr.TaskDuration))
-
-		mr.latencies.queue.add(tr.QueueDuration)
-		mr.latencies.task.add(tr.TaskDuration)
-
-		if mr.numTasks >= mr.numIntervalTasks {
-
-			writeRow()
-			mr.reset()
-
-			if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
-				cd.writer.Flush()
-				if err := cd.writer.Error(); err != nil {
-					cd.setErr(err) // sets error state in multiple goroutine safe way
+		for {
+			tr, ok := <-lt.resultsChan
+			if !ok {
+				if cd.writeErr == nil && mr.numTasks > 0 {
+					writeRow()
 				}
-				cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				return
+			}
+
+			lt.resultWaitGroup.Done()
+
+			if cd.writeErr != nil {
+				continue
+			}
+
+			if tr.taskResultFlags.isZero() {
+
+				mr.sumLag += tr.Meta.Lag
+
+				if tr.Meta.SampleSize > 0 {
+					ss[ssNextWriteIdx] = tr.Meta.SampleSize
+
+					// advance write pointer forward
+					ssNextWriteIdx = (ssNextWriteIdx + 1) % ssSize
+				}
+
+				continue
+			}
+
+			if mr.intervalID.Before(tr.Meta.IntervalID) {
+				mr.intervalID = tr.Meta.IntervalID
+				mr.numIntervalTasks = tr.Meta.NumIntervalTasks
+				mr.lag = tr.Meta.Lag
+			}
+
+			if mr.minQueueDuration > tr.QueueDuration {
+				mr.minQueueDuration = tr.QueueDuration
+			}
+
+			if mr.minTaskDuration > tr.TaskDuration {
+				mr.minTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxTaskDuration < tr.TaskDuration {
+				mr.maxTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxQueueDuration < tr.QueueDuration {
+				mr.maxQueueDuration = tr.QueueDuration
+			}
+
+			mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
+			mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
+			mr.numPass += int(tr.Passed)
+			mr.numFail += int(tr.Errored)
+			mr.numPanic += int(tr.Panicked)
+			mr.numRetry += int(tr.RetryQueued)
+
+			mr.numTasks++
+
+			mr.welfords.queue.Update(mr.numTasks, float64(tr.QueueDuration))
+			mr.welfords.task.Update(mr.numTasks, float64(tr.TaskDuration))
+
+			mr.latencies.queue.add(tr.QueueDuration)
+			mr.latencies.task.add(tr.TaskDuration)
+
+			if mr.numTasks >= ss[ssReadIdx] {
+
+				writeRow()
+				mr.reset()
+
+				// advance read pointer forward
+				ssReadIdx = (ssReadIdx + 1) % ssSize
+
+				if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
+					cd.writer.Flush()
+					if err := cd.writer.Error(); err != nil {
+						cd.setErr(err) // sets error state in multiple goroutine safe way
+					}
+					cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				}
 			}
 		}
 	}
 }
 
-func (lt *Loadtest) resultsHandler_retryEnabled_maxTasksNotGTZero_percentileEnabled_varianceDisabled() {
+func (lt *Loadtest) resultsHandler_retryEnabled_maxTasksNotGTZero_percentileEnabled_varianceDisabled() func() {
 
-	cd := &lt.csvData
-	var mr metricRecord_retryEnabled_maxTasksNotGTZero_percentileEnabled_varianceDisabled
-	mr.latencies = lt.latencies
-	mr.reset()
+	// construct ring buffer of sample sizes (ss)
+	ssSize := lt.maxLiveSamples
+	ss := make([]int, ssSize)
+	var ssNextWriteIdx int
+	var ssReadIdx int
 
-	var writeRow func()
-	{
-		f := lt.writeOutputCsvRow_retryEnabled_maxTasksNotGTZero_percentileEnabled_varianceDisabled()
-		writeRow = func() {
+	return func() {
+		cd := &lt.csvData
+		var mr metricRecord_retryEnabled_maxTasksNotGTZero_percentileEnabled_varianceDisabled
+		mr.latencies = lt.latencies
+		mr.reset()
 
-			f(mr)
-		}
-	}
+		var writeRow func()
+		{
+			f := lt.writeOutputCsvRow_retryEnabled_maxTasksNotGTZero_percentileEnabled_varianceDisabled()
+			writeRow = func() {
 
-	cd.flushDeadline = time.Now().Add(cd.flushInterval)
-
-	for {
-		tr, ok := <-lt.resultsChan
-		if !ok {
-			if cd.writeErr == nil && mr.numTasks > 0 {
-				writeRow()
+				f(mr)
 			}
-			return
 		}
 
-		lt.resultWaitGroup.Done()
+		cd.flushDeadline = time.Now().Add(cd.flushInterval)
 
-		if cd.writeErr != nil {
-			continue
-		}
-
-		if tr.taskResultFlags.isZero() {
-
-			mr.sumLag += tr.Meta.Lag
-
-			continue
-		}
-
-		if mr.intervalID.Before(tr.Meta.IntervalID) {
-			mr.intervalID = tr.Meta.IntervalID
-			mr.numIntervalTasks = tr.Meta.NumIntervalTasks
-			mr.lag = tr.Meta.Lag
-		}
-
-		if mr.minQueueDuration > tr.QueueDuration {
-			mr.minQueueDuration = tr.QueueDuration
-		}
-
-		if mr.minTaskDuration > tr.TaskDuration {
-			mr.minTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxTaskDuration < tr.TaskDuration {
-			mr.maxTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxQueueDuration < tr.QueueDuration {
-			mr.maxQueueDuration = tr.QueueDuration
-		}
-
-		mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
-		mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
-		mr.numPass += int(tr.Passed)
-		mr.numFail += int(tr.Errored)
-		mr.numPanic += int(tr.Panicked)
-		mr.numRetry += int(tr.RetryQueued)
-
-		mr.numTasks++
-
-		mr.latencies.queue.add(tr.QueueDuration)
-		mr.latencies.task.add(tr.TaskDuration)
-
-		if mr.numTasks >= mr.numIntervalTasks {
-
-			writeRow()
-			mr.reset()
-
-			if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
-				cd.writer.Flush()
-				if err := cd.writer.Error(); err != nil {
-					cd.setErr(err) // sets error state in multiple goroutine safe way
+		for {
+			tr, ok := <-lt.resultsChan
+			if !ok {
+				if cd.writeErr == nil && mr.numTasks > 0 {
+					writeRow()
 				}
-				cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				return
+			}
+
+			lt.resultWaitGroup.Done()
+
+			if cd.writeErr != nil {
+				continue
+			}
+
+			if tr.taskResultFlags.isZero() {
+
+				mr.sumLag += tr.Meta.Lag
+
+				if tr.Meta.SampleSize > 0 {
+					ss[ssNextWriteIdx] = tr.Meta.SampleSize
+
+					// advance write pointer forward
+					ssNextWriteIdx = (ssNextWriteIdx + 1) % ssSize
+				}
+
+				continue
+			}
+
+			if mr.intervalID.Before(tr.Meta.IntervalID) {
+				mr.intervalID = tr.Meta.IntervalID
+				mr.numIntervalTasks = tr.Meta.NumIntervalTasks
+				mr.lag = tr.Meta.Lag
+			}
+
+			if mr.minQueueDuration > tr.QueueDuration {
+				mr.minQueueDuration = tr.QueueDuration
+			}
+
+			if mr.minTaskDuration > tr.TaskDuration {
+				mr.minTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxTaskDuration < tr.TaskDuration {
+				mr.maxTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxQueueDuration < tr.QueueDuration {
+				mr.maxQueueDuration = tr.QueueDuration
+			}
+
+			mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
+			mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
+			mr.numPass += int(tr.Passed)
+			mr.numFail += int(tr.Errored)
+			mr.numPanic += int(tr.Panicked)
+			mr.numRetry += int(tr.RetryQueued)
+
+			mr.numTasks++
+
+			mr.latencies.queue.add(tr.QueueDuration)
+			mr.latencies.task.add(tr.TaskDuration)
+
+			if mr.numTasks >= ss[ssReadIdx] {
+
+				writeRow()
+				mr.reset()
+
+				// advance read pointer forward
+				ssReadIdx = (ssReadIdx + 1) % ssSize
+
+				if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
+					cd.writer.Flush()
+					if err := cd.writer.Error(); err != nil {
+						cd.setErr(err) // sets error state in multiple goroutine safe way
+					}
+					cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				}
 			}
 		}
 	}
 }
 
-func (lt *Loadtest) resultsHandler_retryEnabled_maxTasksNotGTZero_percentileDisabled_varianceEnabled() {
+func (lt *Loadtest) resultsHandler_retryEnabled_maxTasksNotGTZero_percentileDisabled_varianceEnabled() func() {
 
-	cd := &lt.csvData
-	var mr metricRecord_retryEnabled_maxTasksNotGTZero_percentileDisabled_varianceEnabled
-	mr.reset()
+	// construct ring buffer of sample sizes (ss)
+	ssSize := lt.maxLiveSamples
+	ss := make([]int, ssSize)
+	var ssNextWriteIdx int
+	var ssReadIdx int
 
-	var writeRow func()
-	{
-		f := lt.writeOutputCsvRow_retryEnabled_maxTasksNotGTZero_percentileDisabled_varianceEnabled()
-		writeRow = func() {
+	return func() {
+		cd := &lt.csvData
+		var mr metricRecord_retryEnabled_maxTasksNotGTZero_percentileDisabled_varianceEnabled
+		mr.reset()
 
-			f(mr)
-		}
-	}
+		var writeRow func()
+		{
+			f := lt.writeOutputCsvRow_retryEnabled_maxTasksNotGTZero_percentileDisabled_varianceEnabled()
+			writeRow = func() {
 
-	cd.flushDeadline = time.Now().Add(cd.flushInterval)
-
-	for {
-		tr, ok := <-lt.resultsChan
-		if !ok {
-			if cd.writeErr == nil && mr.numTasks > 0 {
-				writeRow()
+				f(mr)
 			}
-			return
 		}
 
-		lt.resultWaitGroup.Done()
+		cd.flushDeadline = time.Now().Add(cd.flushInterval)
 
-		if cd.writeErr != nil {
-			continue
-		}
-
-		if tr.taskResultFlags.isZero() {
-
-			mr.sumLag += tr.Meta.Lag
-
-			continue
-		}
-
-		if mr.intervalID.Before(tr.Meta.IntervalID) {
-			mr.intervalID = tr.Meta.IntervalID
-			mr.numIntervalTasks = tr.Meta.NumIntervalTasks
-			mr.lag = tr.Meta.Lag
-		}
-
-		if mr.minQueueDuration > tr.QueueDuration {
-			mr.minQueueDuration = tr.QueueDuration
-		}
-
-		if mr.minTaskDuration > tr.TaskDuration {
-			mr.minTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxTaskDuration < tr.TaskDuration {
-			mr.maxTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxQueueDuration < tr.QueueDuration {
-			mr.maxQueueDuration = tr.QueueDuration
-		}
-
-		mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
-		mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
-		mr.numPass += int(tr.Passed)
-		mr.numFail += int(tr.Errored)
-		mr.numPanic += int(tr.Panicked)
-		mr.numRetry += int(tr.RetryQueued)
-
-		mr.numTasks++
-
-		mr.welfords.queue.Update(mr.numTasks, float64(tr.QueueDuration))
-		mr.welfords.task.Update(mr.numTasks, float64(tr.TaskDuration))
-
-		if mr.numTasks >= mr.numIntervalTasks {
-
-			writeRow()
-			mr.reset()
-
-			if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
-				cd.writer.Flush()
-				if err := cd.writer.Error(); err != nil {
-					cd.setErr(err) // sets error state in multiple goroutine safe way
+		for {
+			tr, ok := <-lt.resultsChan
+			if !ok {
+				if cd.writeErr == nil && mr.numTasks > 0 {
+					writeRow()
 				}
-				cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				return
+			}
+
+			lt.resultWaitGroup.Done()
+
+			if cd.writeErr != nil {
+				continue
+			}
+
+			if tr.taskResultFlags.isZero() {
+
+				mr.sumLag += tr.Meta.Lag
+
+				if tr.Meta.SampleSize > 0 {
+					ss[ssNextWriteIdx] = tr.Meta.SampleSize
+
+					// advance write pointer forward
+					ssNextWriteIdx = (ssNextWriteIdx + 1) % ssSize
+				}
+
+				continue
+			}
+
+			if mr.intervalID.Before(tr.Meta.IntervalID) {
+				mr.intervalID = tr.Meta.IntervalID
+				mr.numIntervalTasks = tr.Meta.NumIntervalTasks
+				mr.lag = tr.Meta.Lag
+			}
+
+			if mr.minQueueDuration > tr.QueueDuration {
+				mr.minQueueDuration = tr.QueueDuration
+			}
+
+			if mr.minTaskDuration > tr.TaskDuration {
+				mr.minTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxTaskDuration < tr.TaskDuration {
+				mr.maxTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxQueueDuration < tr.QueueDuration {
+				mr.maxQueueDuration = tr.QueueDuration
+			}
+
+			mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
+			mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
+			mr.numPass += int(tr.Passed)
+			mr.numFail += int(tr.Errored)
+			mr.numPanic += int(tr.Panicked)
+			mr.numRetry += int(tr.RetryQueued)
+
+			mr.numTasks++
+
+			mr.welfords.queue.Update(mr.numTasks, float64(tr.QueueDuration))
+			mr.welfords.task.Update(mr.numTasks, float64(tr.TaskDuration))
+
+			if mr.numTasks >= ss[ssReadIdx] {
+
+				writeRow()
+				mr.reset()
+
+				// advance read pointer forward
+				ssReadIdx = (ssReadIdx + 1) % ssSize
+
+				if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
+					cd.writer.Flush()
+					if err := cd.writer.Error(); err != nil {
+						cd.setErr(err) // sets error state in multiple goroutine safe way
+					}
+					cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				}
 			}
 		}
 	}
 }
 
-func (lt *Loadtest) resultsHandler_retryEnabled_maxTasksNotGTZero_percentileDisabled_varianceDisabled() {
+func (lt *Loadtest) resultsHandler_retryEnabled_maxTasksNotGTZero_percentileDisabled_varianceDisabled() func() {
 
-	cd := &lt.csvData
-	var mr metricRecord_retryEnabled_maxTasksNotGTZero_percentileDisabled_varianceDisabled
-	mr.reset()
+	// construct ring buffer of sample sizes (ss)
+	ssSize := lt.maxLiveSamples
+	ss := make([]int, ssSize)
+	var ssNextWriteIdx int
+	var ssReadIdx int
 
-	var writeRow func()
-	{
-		f := lt.writeOutputCsvRow_retryEnabled_maxTasksNotGTZero_percentileDisabled_varianceDisabled()
-		writeRow = func() {
+	return func() {
+		cd := &lt.csvData
+		var mr metricRecord_retryEnabled_maxTasksNotGTZero_percentileDisabled_varianceDisabled
+		mr.reset()
 
-			f(mr)
-		}
-	}
+		var writeRow func()
+		{
+			f := lt.writeOutputCsvRow_retryEnabled_maxTasksNotGTZero_percentileDisabled_varianceDisabled()
+			writeRow = func() {
 
-	cd.flushDeadline = time.Now().Add(cd.flushInterval)
-
-	for {
-		tr, ok := <-lt.resultsChan
-		if !ok {
-			if cd.writeErr == nil && mr.numTasks > 0 {
-				writeRow()
+				f(mr)
 			}
-			return
 		}
 
-		lt.resultWaitGroup.Done()
+		cd.flushDeadline = time.Now().Add(cd.flushInterval)
 
-		if cd.writeErr != nil {
-			continue
-		}
-
-		if tr.taskResultFlags.isZero() {
-
-			mr.sumLag += tr.Meta.Lag
-
-			continue
-		}
-
-		if mr.intervalID.Before(tr.Meta.IntervalID) {
-			mr.intervalID = tr.Meta.IntervalID
-			mr.numIntervalTasks = tr.Meta.NumIntervalTasks
-			mr.lag = tr.Meta.Lag
-		}
-
-		if mr.minQueueDuration > tr.QueueDuration {
-			mr.minQueueDuration = tr.QueueDuration
-		}
-
-		if mr.minTaskDuration > tr.TaskDuration {
-			mr.minTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxTaskDuration < tr.TaskDuration {
-			mr.maxTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxQueueDuration < tr.QueueDuration {
-			mr.maxQueueDuration = tr.QueueDuration
-		}
-
-		mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
-		mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
-		mr.numPass += int(tr.Passed)
-		mr.numFail += int(tr.Errored)
-		mr.numPanic += int(tr.Panicked)
-		mr.numRetry += int(tr.RetryQueued)
-
-		mr.numTasks++
-
-		if mr.numTasks >= mr.numIntervalTasks {
-
-			writeRow()
-			mr.reset()
-
-			if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
-				cd.writer.Flush()
-				if err := cd.writer.Error(); err != nil {
-					cd.setErr(err) // sets error state in multiple goroutine safe way
+		for {
+			tr, ok := <-lt.resultsChan
+			if !ok {
+				if cd.writeErr == nil && mr.numTasks > 0 {
+					writeRow()
 				}
-				cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				return
+			}
+
+			lt.resultWaitGroup.Done()
+
+			if cd.writeErr != nil {
+				continue
+			}
+
+			if tr.taskResultFlags.isZero() {
+
+				mr.sumLag += tr.Meta.Lag
+
+				if tr.Meta.SampleSize > 0 {
+					ss[ssNextWriteIdx] = tr.Meta.SampleSize
+
+					// advance write pointer forward
+					ssNextWriteIdx = (ssNextWriteIdx + 1) % ssSize
+				}
+
+				continue
+			}
+
+			if mr.intervalID.Before(tr.Meta.IntervalID) {
+				mr.intervalID = tr.Meta.IntervalID
+				mr.numIntervalTasks = tr.Meta.NumIntervalTasks
+				mr.lag = tr.Meta.Lag
+			}
+
+			if mr.minQueueDuration > tr.QueueDuration {
+				mr.minQueueDuration = tr.QueueDuration
+			}
+
+			if mr.minTaskDuration > tr.TaskDuration {
+				mr.minTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxTaskDuration < tr.TaskDuration {
+				mr.maxTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxQueueDuration < tr.QueueDuration {
+				mr.maxQueueDuration = tr.QueueDuration
+			}
+
+			mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
+			mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
+			mr.numPass += int(tr.Passed)
+			mr.numFail += int(tr.Errored)
+			mr.numPanic += int(tr.Panicked)
+			mr.numRetry += int(tr.RetryQueued)
+
+			mr.numTasks++
+
+			if mr.numTasks >= ss[ssReadIdx] {
+
+				writeRow()
+				mr.reset()
+
+				// advance read pointer forward
+				ssReadIdx = (ssReadIdx + 1) % ssSize
+
+				if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
+					cd.writer.Flush()
+					if err := cd.writer.Error(); err != nil {
+						cd.setErr(err) // sets error state in multiple goroutine safe way
+					}
+					cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				}
 			}
 		}
 	}
 }
 
-func (lt *Loadtest) resultsHandler_retryDisabled_maxTasksGTZero_percentileEnabled_varianceEnabled() {
+func (lt *Loadtest) resultsHandler_retryDisabled_maxTasksGTZero_percentileEnabled_varianceEnabled() func() {
 
-	cd := &lt.csvData
-	var mr metricRecord_retryDisabled_maxTasksGTZero_percentileEnabled_varianceEnabled
-	mr.latencies = lt.latencies
-	mr.reset()
+	// construct ring buffer of sample sizes (ss)
+	ssSize := lt.maxLiveSamples
+	ss := make([]int, ssSize)
+	var ssNextWriteIdx int
+	var ssReadIdx int
 
-	var writeRow func()
-	{
-		f := lt.writeOutputCsvRow_retryDisabled_maxTasksGTZero_percentileEnabled_varianceEnabled()
-		writeRow = func() {
+	return func() {
+		cd := &lt.csvData
+		var mr metricRecord_retryDisabled_maxTasksGTZero_percentileEnabled_varianceEnabled
+		mr.latencies = lt.latencies
+		mr.reset()
 
-			mr.totalNumTasks += mr.numTasks
+		var writeRow func()
+		{
+			f := lt.writeOutputCsvRow_retryDisabled_maxTasksGTZero_percentileEnabled_varianceEnabled()
+			writeRow = func() {
 
-			f(mr)
-		}
-	}
+				mr.totalNumTasks += mr.numTasks
 
-	cd.flushDeadline = time.Now().Add(cd.flushInterval)
-
-	for {
-		tr, ok := <-lt.resultsChan
-		if !ok {
-			if cd.writeErr == nil && mr.numTasks > 0 {
-				writeRow()
+				f(mr)
 			}
-			return
 		}
 
-		lt.resultWaitGroup.Done()
+		cd.flushDeadline = time.Now().Add(cd.flushInterval)
 
-		if cd.writeErr != nil {
-			continue
-		}
-
-		if tr.taskResultFlags.isZero() {
-
-			mr.sumLag += tr.Meta.Lag
-
-			continue
-		}
-
-		if mr.intervalID.Before(tr.Meta.IntervalID) {
-			mr.intervalID = tr.Meta.IntervalID
-			mr.numIntervalTasks = tr.Meta.NumIntervalTasks
-			mr.lag = tr.Meta.Lag
-		}
-
-		if mr.minQueueDuration > tr.QueueDuration {
-			mr.minQueueDuration = tr.QueueDuration
-		}
-
-		if mr.minTaskDuration > tr.TaskDuration {
-			mr.minTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxTaskDuration < tr.TaskDuration {
-			mr.maxTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxQueueDuration < tr.QueueDuration {
-			mr.maxQueueDuration = tr.QueueDuration
-		}
-
-		mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
-		mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
-		mr.numPass += int(tr.Passed)
-		mr.numFail += int(tr.Errored)
-		mr.numPanic += int(tr.Panicked)
-
-		mr.numTasks++
-
-		mr.welfords.queue.Update(mr.numTasks, float64(tr.QueueDuration))
-		mr.welfords.task.Update(mr.numTasks, float64(tr.TaskDuration))
-
-		mr.latencies.queue.add(tr.QueueDuration)
-		mr.latencies.task.add(tr.TaskDuration)
-
-		if mr.numTasks >= mr.numIntervalTasks {
-
-			writeRow()
-			mr.reset()
-
-			if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
-				cd.writer.Flush()
-				if err := cd.writer.Error(); err != nil {
-					cd.setErr(err) // sets error state in multiple goroutine safe way
+		for {
+			tr, ok := <-lt.resultsChan
+			if !ok {
+				if cd.writeErr == nil && mr.numTasks > 0 {
+					writeRow()
 				}
-				cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				return
+			}
+
+			lt.resultWaitGroup.Done()
+
+			if cd.writeErr != nil {
+				continue
+			}
+
+			if tr.taskResultFlags.isZero() {
+
+				mr.sumLag += tr.Meta.Lag
+
+				if tr.Meta.SampleSize > 0 {
+					ss[ssNextWriteIdx] = tr.Meta.SampleSize
+
+					// advance write pointer forward
+					ssNextWriteIdx = (ssNextWriteIdx + 1) % ssSize
+				}
+
+				continue
+			}
+
+			if mr.intervalID.Before(tr.Meta.IntervalID) {
+				mr.intervalID = tr.Meta.IntervalID
+				mr.numIntervalTasks = tr.Meta.NumIntervalTasks
+				mr.lag = tr.Meta.Lag
+			}
+
+			if mr.minQueueDuration > tr.QueueDuration {
+				mr.minQueueDuration = tr.QueueDuration
+			}
+
+			if mr.minTaskDuration > tr.TaskDuration {
+				mr.minTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxTaskDuration < tr.TaskDuration {
+				mr.maxTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxQueueDuration < tr.QueueDuration {
+				mr.maxQueueDuration = tr.QueueDuration
+			}
+
+			mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
+			mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
+			mr.numPass += int(tr.Passed)
+			mr.numFail += int(tr.Errored)
+			mr.numPanic += int(tr.Panicked)
+
+			mr.numTasks++
+
+			mr.welfords.queue.Update(mr.numTasks, float64(tr.QueueDuration))
+			mr.welfords.task.Update(mr.numTasks, float64(tr.TaskDuration))
+
+			mr.latencies.queue.add(tr.QueueDuration)
+			mr.latencies.task.add(tr.TaskDuration)
+
+			if mr.numTasks >= ss[ssReadIdx] {
+
+				writeRow()
+				mr.reset()
+
+				// advance read pointer forward
+				ssReadIdx = (ssReadIdx + 1) % ssSize
+
+				if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
+					cd.writer.Flush()
+					if err := cd.writer.Error(); err != nil {
+						cd.setErr(err) // sets error state in multiple goroutine safe way
+					}
+					cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				}
 			}
 		}
 	}
 }
 
-func (lt *Loadtest) resultsHandler_retryDisabled_maxTasksGTZero_percentileEnabled_varianceDisabled() {
+func (lt *Loadtest) resultsHandler_retryDisabled_maxTasksGTZero_percentileEnabled_varianceDisabled() func() {
 
-	cd := &lt.csvData
-	var mr metricRecord_retryDisabled_maxTasksGTZero_percentileEnabled_varianceDisabled
-	mr.latencies = lt.latencies
-	mr.reset()
+	// construct ring buffer of sample sizes (ss)
+	ssSize := lt.maxLiveSamples
+	ss := make([]int, ssSize)
+	var ssNextWriteIdx int
+	var ssReadIdx int
 
-	var writeRow func()
-	{
-		f := lt.writeOutputCsvRow_retryDisabled_maxTasksGTZero_percentileEnabled_varianceDisabled()
-		writeRow = func() {
+	return func() {
+		cd := &lt.csvData
+		var mr metricRecord_retryDisabled_maxTasksGTZero_percentileEnabled_varianceDisabled
+		mr.latencies = lt.latencies
+		mr.reset()
 
-			mr.totalNumTasks += mr.numTasks
+		var writeRow func()
+		{
+			f := lt.writeOutputCsvRow_retryDisabled_maxTasksGTZero_percentileEnabled_varianceDisabled()
+			writeRow = func() {
 
-			f(mr)
-		}
-	}
+				mr.totalNumTasks += mr.numTasks
 
-	cd.flushDeadline = time.Now().Add(cd.flushInterval)
-
-	for {
-		tr, ok := <-lt.resultsChan
-		if !ok {
-			if cd.writeErr == nil && mr.numTasks > 0 {
-				writeRow()
+				f(mr)
 			}
-			return
 		}
 
-		lt.resultWaitGroup.Done()
+		cd.flushDeadline = time.Now().Add(cd.flushInterval)
 
-		if cd.writeErr != nil {
-			continue
-		}
-
-		if tr.taskResultFlags.isZero() {
-
-			mr.sumLag += tr.Meta.Lag
-
-			continue
-		}
-
-		if mr.intervalID.Before(tr.Meta.IntervalID) {
-			mr.intervalID = tr.Meta.IntervalID
-			mr.numIntervalTasks = tr.Meta.NumIntervalTasks
-			mr.lag = tr.Meta.Lag
-		}
-
-		if mr.minQueueDuration > tr.QueueDuration {
-			mr.minQueueDuration = tr.QueueDuration
-		}
-
-		if mr.minTaskDuration > tr.TaskDuration {
-			mr.minTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxTaskDuration < tr.TaskDuration {
-			mr.maxTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxQueueDuration < tr.QueueDuration {
-			mr.maxQueueDuration = tr.QueueDuration
-		}
-
-		mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
-		mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
-		mr.numPass += int(tr.Passed)
-		mr.numFail += int(tr.Errored)
-		mr.numPanic += int(tr.Panicked)
-
-		mr.numTasks++
-
-		mr.latencies.queue.add(tr.QueueDuration)
-		mr.latencies.task.add(tr.TaskDuration)
-
-		if mr.numTasks >= mr.numIntervalTasks {
-
-			writeRow()
-			mr.reset()
-
-			if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
-				cd.writer.Flush()
-				if err := cd.writer.Error(); err != nil {
-					cd.setErr(err) // sets error state in multiple goroutine safe way
+		for {
+			tr, ok := <-lt.resultsChan
+			if !ok {
+				if cd.writeErr == nil && mr.numTasks > 0 {
+					writeRow()
 				}
-				cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				return
+			}
+
+			lt.resultWaitGroup.Done()
+
+			if cd.writeErr != nil {
+				continue
+			}
+
+			if tr.taskResultFlags.isZero() {
+
+				mr.sumLag += tr.Meta.Lag
+
+				if tr.Meta.SampleSize > 0 {
+					ss[ssNextWriteIdx] = tr.Meta.SampleSize
+
+					// advance write pointer forward
+					ssNextWriteIdx = (ssNextWriteIdx + 1) % ssSize
+				}
+
+				continue
+			}
+
+			if mr.intervalID.Before(tr.Meta.IntervalID) {
+				mr.intervalID = tr.Meta.IntervalID
+				mr.numIntervalTasks = tr.Meta.NumIntervalTasks
+				mr.lag = tr.Meta.Lag
+			}
+
+			if mr.minQueueDuration > tr.QueueDuration {
+				mr.minQueueDuration = tr.QueueDuration
+			}
+
+			if mr.minTaskDuration > tr.TaskDuration {
+				mr.minTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxTaskDuration < tr.TaskDuration {
+				mr.maxTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxQueueDuration < tr.QueueDuration {
+				mr.maxQueueDuration = tr.QueueDuration
+			}
+
+			mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
+			mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
+			mr.numPass += int(tr.Passed)
+			mr.numFail += int(tr.Errored)
+			mr.numPanic += int(tr.Panicked)
+
+			mr.numTasks++
+
+			mr.latencies.queue.add(tr.QueueDuration)
+			mr.latencies.task.add(tr.TaskDuration)
+
+			if mr.numTasks >= ss[ssReadIdx] {
+
+				writeRow()
+				mr.reset()
+
+				// advance read pointer forward
+				ssReadIdx = (ssReadIdx + 1) % ssSize
+
+				if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
+					cd.writer.Flush()
+					if err := cd.writer.Error(); err != nil {
+						cd.setErr(err) // sets error state in multiple goroutine safe way
+					}
+					cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				}
 			}
 		}
 	}
 }
 
-func (lt *Loadtest) resultsHandler_retryDisabled_maxTasksGTZero_percentileDisabled_varianceEnabled() {
+func (lt *Loadtest) resultsHandler_retryDisabled_maxTasksGTZero_percentileDisabled_varianceEnabled() func() {
 
-	cd := &lt.csvData
-	var mr metricRecord_retryDisabled_maxTasksGTZero_percentileDisabled_varianceEnabled
-	mr.reset()
+	// construct ring buffer of sample sizes (ss)
+	ssSize := lt.maxLiveSamples
+	ss := make([]int, ssSize)
+	var ssNextWriteIdx int
+	var ssReadIdx int
 
-	var writeRow func()
-	{
-		f := lt.writeOutputCsvRow_retryDisabled_maxTasksGTZero_percentileDisabled_varianceEnabled()
-		writeRow = func() {
+	return func() {
+		cd := &lt.csvData
+		var mr metricRecord_retryDisabled_maxTasksGTZero_percentileDisabled_varianceEnabled
+		mr.reset()
 
-			mr.totalNumTasks += mr.numTasks
+		var writeRow func()
+		{
+			f := lt.writeOutputCsvRow_retryDisabled_maxTasksGTZero_percentileDisabled_varianceEnabled()
+			writeRow = func() {
 
-			f(mr)
-		}
-	}
+				mr.totalNumTasks += mr.numTasks
 
-	cd.flushDeadline = time.Now().Add(cd.flushInterval)
-
-	for {
-		tr, ok := <-lt.resultsChan
-		if !ok {
-			if cd.writeErr == nil && mr.numTasks > 0 {
-				writeRow()
+				f(mr)
 			}
-			return
 		}
 
-		lt.resultWaitGroup.Done()
+		cd.flushDeadline = time.Now().Add(cd.flushInterval)
 
-		if cd.writeErr != nil {
-			continue
-		}
-
-		if tr.taskResultFlags.isZero() {
-
-			mr.sumLag += tr.Meta.Lag
-
-			continue
-		}
-
-		if mr.intervalID.Before(tr.Meta.IntervalID) {
-			mr.intervalID = tr.Meta.IntervalID
-			mr.numIntervalTasks = tr.Meta.NumIntervalTasks
-			mr.lag = tr.Meta.Lag
-		}
-
-		if mr.minQueueDuration > tr.QueueDuration {
-			mr.minQueueDuration = tr.QueueDuration
-		}
-
-		if mr.minTaskDuration > tr.TaskDuration {
-			mr.minTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxTaskDuration < tr.TaskDuration {
-			mr.maxTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxQueueDuration < tr.QueueDuration {
-			mr.maxQueueDuration = tr.QueueDuration
-		}
-
-		mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
-		mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
-		mr.numPass += int(tr.Passed)
-		mr.numFail += int(tr.Errored)
-		mr.numPanic += int(tr.Panicked)
-
-		mr.numTasks++
-
-		mr.welfords.queue.Update(mr.numTasks, float64(tr.QueueDuration))
-		mr.welfords.task.Update(mr.numTasks, float64(tr.TaskDuration))
-
-		if mr.numTasks >= mr.numIntervalTasks {
-
-			writeRow()
-			mr.reset()
-
-			if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
-				cd.writer.Flush()
-				if err := cd.writer.Error(); err != nil {
-					cd.setErr(err) // sets error state in multiple goroutine safe way
+		for {
+			tr, ok := <-lt.resultsChan
+			if !ok {
+				if cd.writeErr == nil && mr.numTasks > 0 {
+					writeRow()
 				}
-				cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				return
+			}
+
+			lt.resultWaitGroup.Done()
+
+			if cd.writeErr != nil {
+				continue
+			}
+
+			if tr.taskResultFlags.isZero() {
+
+				mr.sumLag += tr.Meta.Lag
+
+				if tr.Meta.SampleSize > 0 {
+					ss[ssNextWriteIdx] = tr.Meta.SampleSize
+
+					// advance write pointer forward
+					ssNextWriteIdx = (ssNextWriteIdx + 1) % ssSize
+				}
+
+				continue
+			}
+
+			if mr.intervalID.Before(tr.Meta.IntervalID) {
+				mr.intervalID = tr.Meta.IntervalID
+				mr.numIntervalTasks = tr.Meta.NumIntervalTasks
+				mr.lag = tr.Meta.Lag
+			}
+
+			if mr.minQueueDuration > tr.QueueDuration {
+				mr.minQueueDuration = tr.QueueDuration
+			}
+
+			if mr.minTaskDuration > tr.TaskDuration {
+				mr.minTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxTaskDuration < tr.TaskDuration {
+				mr.maxTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxQueueDuration < tr.QueueDuration {
+				mr.maxQueueDuration = tr.QueueDuration
+			}
+
+			mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
+			mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
+			mr.numPass += int(tr.Passed)
+			mr.numFail += int(tr.Errored)
+			mr.numPanic += int(tr.Panicked)
+
+			mr.numTasks++
+
+			mr.welfords.queue.Update(mr.numTasks, float64(tr.QueueDuration))
+			mr.welfords.task.Update(mr.numTasks, float64(tr.TaskDuration))
+
+			if mr.numTasks >= ss[ssReadIdx] {
+
+				writeRow()
+				mr.reset()
+
+				// advance read pointer forward
+				ssReadIdx = (ssReadIdx + 1) % ssSize
+
+				if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
+					cd.writer.Flush()
+					if err := cd.writer.Error(); err != nil {
+						cd.setErr(err) // sets error state in multiple goroutine safe way
+					}
+					cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				}
 			}
 		}
 	}
 }
 
-func (lt *Loadtest) resultsHandler_retryDisabled_maxTasksGTZero_percentileDisabled_varianceDisabled() {
+func (lt *Loadtest) resultsHandler_retryDisabled_maxTasksGTZero_percentileDisabled_varianceDisabled() func() {
 
-	cd := &lt.csvData
-	var mr metricRecord_retryDisabled_maxTasksGTZero_percentileDisabled_varianceDisabled
-	mr.reset()
+	// construct ring buffer of sample sizes (ss)
+	ssSize := lt.maxLiveSamples
+	ss := make([]int, ssSize)
+	var ssNextWriteIdx int
+	var ssReadIdx int
 
-	var writeRow func()
-	{
-		f := lt.writeOutputCsvRow_retryDisabled_maxTasksGTZero_percentileDisabled_varianceDisabled()
-		writeRow = func() {
+	return func() {
+		cd := &lt.csvData
+		var mr metricRecord_retryDisabled_maxTasksGTZero_percentileDisabled_varianceDisabled
+		mr.reset()
 
-			mr.totalNumTasks += mr.numTasks
+		var writeRow func()
+		{
+			f := lt.writeOutputCsvRow_retryDisabled_maxTasksGTZero_percentileDisabled_varianceDisabled()
+			writeRow = func() {
 
-			f(mr)
-		}
-	}
+				mr.totalNumTasks += mr.numTasks
 
-	cd.flushDeadline = time.Now().Add(cd.flushInterval)
-
-	for {
-		tr, ok := <-lt.resultsChan
-		if !ok {
-			if cd.writeErr == nil && mr.numTasks > 0 {
-				writeRow()
+				f(mr)
 			}
-			return
 		}
 
-		lt.resultWaitGroup.Done()
+		cd.flushDeadline = time.Now().Add(cd.flushInterval)
 
-		if cd.writeErr != nil {
-			continue
-		}
-
-		if tr.taskResultFlags.isZero() {
-
-			mr.sumLag += tr.Meta.Lag
-
-			continue
-		}
-
-		if mr.intervalID.Before(tr.Meta.IntervalID) {
-			mr.intervalID = tr.Meta.IntervalID
-			mr.numIntervalTasks = tr.Meta.NumIntervalTasks
-			mr.lag = tr.Meta.Lag
-		}
-
-		if mr.minQueueDuration > tr.QueueDuration {
-			mr.minQueueDuration = tr.QueueDuration
-		}
-
-		if mr.minTaskDuration > tr.TaskDuration {
-			mr.minTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxTaskDuration < tr.TaskDuration {
-			mr.maxTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxQueueDuration < tr.QueueDuration {
-			mr.maxQueueDuration = tr.QueueDuration
-		}
-
-		mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
-		mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
-		mr.numPass += int(tr.Passed)
-		mr.numFail += int(tr.Errored)
-		mr.numPanic += int(tr.Panicked)
-
-		mr.numTasks++
-
-		if mr.numTasks >= mr.numIntervalTasks {
-
-			writeRow()
-			mr.reset()
-
-			if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
-				cd.writer.Flush()
-				if err := cd.writer.Error(); err != nil {
-					cd.setErr(err) // sets error state in multiple goroutine safe way
+		for {
+			tr, ok := <-lt.resultsChan
+			if !ok {
+				if cd.writeErr == nil && mr.numTasks > 0 {
+					writeRow()
 				}
-				cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				return
+			}
+
+			lt.resultWaitGroup.Done()
+
+			if cd.writeErr != nil {
+				continue
+			}
+
+			if tr.taskResultFlags.isZero() {
+
+				mr.sumLag += tr.Meta.Lag
+
+				if tr.Meta.SampleSize > 0 {
+					ss[ssNextWriteIdx] = tr.Meta.SampleSize
+
+					// advance write pointer forward
+					ssNextWriteIdx = (ssNextWriteIdx + 1) % ssSize
+				}
+
+				continue
+			}
+
+			if mr.intervalID.Before(tr.Meta.IntervalID) {
+				mr.intervalID = tr.Meta.IntervalID
+				mr.numIntervalTasks = tr.Meta.NumIntervalTasks
+				mr.lag = tr.Meta.Lag
+			}
+
+			if mr.minQueueDuration > tr.QueueDuration {
+				mr.minQueueDuration = tr.QueueDuration
+			}
+
+			if mr.minTaskDuration > tr.TaskDuration {
+				mr.minTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxTaskDuration < tr.TaskDuration {
+				mr.maxTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxQueueDuration < tr.QueueDuration {
+				mr.maxQueueDuration = tr.QueueDuration
+			}
+
+			mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
+			mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
+			mr.numPass += int(tr.Passed)
+			mr.numFail += int(tr.Errored)
+			mr.numPanic += int(tr.Panicked)
+
+			mr.numTasks++
+
+			if mr.numTasks >= ss[ssReadIdx] {
+
+				writeRow()
+				mr.reset()
+
+				// advance read pointer forward
+				ssReadIdx = (ssReadIdx + 1) % ssSize
+
+				if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
+					cd.writer.Flush()
+					if err := cd.writer.Error(); err != nil {
+						cd.setErr(err) // sets error state in multiple goroutine safe way
+					}
+					cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				}
 			}
 		}
 	}
 }
 
-func (lt *Loadtest) resultsHandler_retryDisabled_maxTasksNotGTZero_percentileEnabled_varianceEnabled() {
+func (lt *Loadtest) resultsHandler_retryDisabled_maxTasksNotGTZero_percentileEnabled_varianceEnabled() func() {
 
-	cd := &lt.csvData
-	var mr metricRecord_retryDisabled_maxTasksNotGTZero_percentileEnabled_varianceEnabled
-	mr.latencies = lt.latencies
-	mr.reset()
+	// construct ring buffer of sample sizes (ss)
+	ssSize := lt.maxLiveSamples
+	ss := make([]int, ssSize)
+	var ssNextWriteIdx int
+	var ssReadIdx int
 
-	var writeRow func()
-	{
-		f := lt.writeOutputCsvRow_retryDisabled_maxTasksNotGTZero_percentileEnabled_varianceEnabled()
-		writeRow = func() {
+	return func() {
+		cd := &lt.csvData
+		var mr metricRecord_retryDisabled_maxTasksNotGTZero_percentileEnabled_varianceEnabled
+		mr.latencies = lt.latencies
+		mr.reset()
 
-			f(mr)
-		}
-	}
+		var writeRow func()
+		{
+			f := lt.writeOutputCsvRow_retryDisabled_maxTasksNotGTZero_percentileEnabled_varianceEnabled()
+			writeRow = func() {
 
-	cd.flushDeadline = time.Now().Add(cd.flushInterval)
-
-	for {
-		tr, ok := <-lt.resultsChan
-		if !ok {
-			if cd.writeErr == nil && mr.numTasks > 0 {
-				writeRow()
+				f(mr)
 			}
-			return
 		}
 
-		lt.resultWaitGroup.Done()
+		cd.flushDeadline = time.Now().Add(cd.flushInterval)
 
-		if cd.writeErr != nil {
-			continue
-		}
-
-		if tr.taskResultFlags.isZero() {
-
-			mr.sumLag += tr.Meta.Lag
-
-			continue
-		}
-
-		if mr.intervalID.Before(tr.Meta.IntervalID) {
-			mr.intervalID = tr.Meta.IntervalID
-			mr.numIntervalTasks = tr.Meta.NumIntervalTasks
-			mr.lag = tr.Meta.Lag
-		}
-
-		if mr.minQueueDuration > tr.QueueDuration {
-			mr.minQueueDuration = tr.QueueDuration
-		}
-
-		if mr.minTaskDuration > tr.TaskDuration {
-			mr.minTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxTaskDuration < tr.TaskDuration {
-			mr.maxTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxQueueDuration < tr.QueueDuration {
-			mr.maxQueueDuration = tr.QueueDuration
-		}
-
-		mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
-		mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
-		mr.numPass += int(tr.Passed)
-		mr.numFail += int(tr.Errored)
-		mr.numPanic += int(tr.Panicked)
-
-		mr.numTasks++
-
-		mr.welfords.queue.Update(mr.numTasks, float64(tr.QueueDuration))
-		mr.welfords.task.Update(mr.numTasks, float64(tr.TaskDuration))
-
-		mr.latencies.queue.add(tr.QueueDuration)
-		mr.latencies.task.add(tr.TaskDuration)
-
-		if mr.numTasks >= mr.numIntervalTasks {
-
-			writeRow()
-			mr.reset()
-
-			if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
-				cd.writer.Flush()
-				if err := cd.writer.Error(); err != nil {
-					cd.setErr(err) // sets error state in multiple goroutine safe way
+		for {
+			tr, ok := <-lt.resultsChan
+			if !ok {
+				if cd.writeErr == nil && mr.numTasks > 0 {
+					writeRow()
 				}
-				cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				return
+			}
+
+			lt.resultWaitGroup.Done()
+
+			if cd.writeErr != nil {
+				continue
+			}
+
+			if tr.taskResultFlags.isZero() {
+
+				mr.sumLag += tr.Meta.Lag
+
+				if tr.Meta.SampleSize > 0 {
+					ss[ssNextWriteIdx] = tr.Meta.SampleSize
+
+					// advance write pointer forward
+					ssNextWriteIdx = (ssNextWriteIdx + 1) % ssSize
+				}
+
+				continue
+			}
+
+			if mr.intervalID.Before(tr.Meta.IntervalID) {
+				mr.intervalID = tr.Meta.IntervalID
+				mr.numIntervalTasks = tr.Meta.NumIntervalTasks
+				mr.lag = tr.Meta.Lag
+			}
+
+			if mr.minQueueDuration > tr.QueueDuration {
+				mr.minQueueDuration = tr.QueueDuration
+			}
+
+			if mr.minTaskDuration > tr.TaskDuration {
+				mr.minTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxTaskDuration < tr.TaskDuration {
+				mr.maxTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxQueueDuration < tr.QueueDuration {
+				mr.maxQueueDuration = tr.QueueDuration
+			}
+
+			mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
+			mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
+			mr.numPass += int(tr.Passed)
+			mr.numFail += int(tr.Errored)
+			mr.numPanic += int(tr.Panicked)
+
+			mr.numTasks++
+
+			mr.welfords.queue.Update(mr.numTasks, float64(tr.QueueDuration))
+			mr.welfords.task.Update(mr.numTasks, float64(tr.TaskDuration))
+
+			mr.latencies.queue.add(tr.QueueDuration)
+			mr.latencies.task.add(tr.TaskDuration)
+
+			if mr.numTasks >= ss[ssReadIdx] {
+
+				writeRow()
+				mr.reset()
+
+				// advance read pointer forward
+				ssReadIdx = (ssReadIdx + 1) % ssSize
+
+				if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
+					cd.writer.Flush()
+					if err := cd.writer.Error(); err != nil {
+						cd.setErr(err) // sets error state in multiple goroutine safe way
+					}
+					cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				}
 			}
 		}
 	}
 }
 
-func (lt *Loadtest) resultsHandler_retryDisabled_maxTasksNotGTZero_percentileEnabled_varianceDisabled() {
+func (lt *Loadtest) resultsHandler_retryDisabled_maxTasksNotGTZero_percentileEnabled_varianceDisabled() func() {
 
-	cd := &lt.csvData
-	var mr metricRecord_retryDisabled_maxTasksNotGTZero_percentileEnabled_varianceDisabled
-	mr.latencies = lt.latencies
-	mr.reset()
+	// construct ring buffer of sample sizes (ss)
+	ssSize := lt.maxLiveSamples
+	ss := make([]int, ssSize)
+	var ssNextWriteIdx int
+	var ssReadIdx int
 
-	var writeRow func()
-	{
-		f := lt.writeOutputCsvRow_retryDisabled_maxTasksNotGTZero_percentileEnabled_varianceDisabled()
-		writeRow = func() {
+	return func() {
+		cd := &lt.csvData
+		var mr metricRecord_retryDisabled_maxTasksNotGTZero_percentileEnabled_varianceDisabled
+		mr.latencies = lt.latencies
+		mr.reset()
 
-			f(mr)
-		}
-	}
+		var writeRow func()
+		{
+			f := lt.writeOutputCsvRow_retryDisabled_maxTasksNotGTZero_percentileEnabled_varianceDisabled()
+			writeRow = func() {
 
-	cd.flushDeadline = time.Now().Add(cd.flushInterval)
-
-	for {
-		tr, ok := <-lt.resultsChan
-		if !ok {
-			if cd.writeErr == nil && mr.numTasks > 0 {
-				writeRow()
+				f(mr)
 			}
-			return
 		}
 
-		lt.resultWaitGroup.Done()
+		cd.flushDeadline = time.Now().Add(cd.flushInterval)
 
-		if cd.writeErr != nil {
-			continue
-		}
-
-		if tr.taskResultFlags.isZero() {
-
-			mr.sumLag += tr.Meta.Lag
-
-			continue
-		}
-
-		if mr.intervalID.Before(tr.Meta.IntervalID) {
-			mr.intervalID = tr.Meta.IntervalID
-			mr.numIntervalTasks = tr.Meta.NumIntervalTasks
-			mr.lag = tr.Meta.Lag
-		}
-
-		if mr.minQueueDuration > tr.QueueDuration {
-			mr.minQueueDuration = tr.QueueDuration
-		}
-
-		if mr.minTaskDuration > tr.TaskDuration {
-			mr.minTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxTaskDuration < tr.TaskDuration {
-			mr.maxTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxQueueDuration < tr.QueueDuration {
-			mr.maxQueueDuration = tr.QueueDuration
-		}
-
-		mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
-		mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
-		mr.numPass += int(tr.Passed)
-		mr.numFail += int(tr.Errored)
-		mr.numPanic += int(tr.Panicked)
-
-		mr.numTasks++
-
-		mr.latencies.queue.add(tr.QueueDuration)
-		mr.latencies.task.add(tr.TaskDuration)
-
-		if mr.numTasks >= mr.numIntervalTasks {
-
-			writeRow()
-			mr.reset()
-
-			if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
-				cd.writer.Flush()
-				if err := cd.writer.Error(); err != nil {
-					cd.setErr(err) // sets error state in multiple goroutine safe way
+		for {
+			tr, ok := <-lt.resultsChan
+			if !ok {
+				if cd.writeErr == nil && mr.numTasks > 0 {
+					writeRow()
 				}
-				cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				return
+			}
+
+			lt.resultWaitGroup.Done()
+
+			if cd.writeErr != nil {
+				continue
+			}
+
+			if tr.taskResultFlags.isZero() {
+
+				mr.sumLag += tr.Meta.Lag
+
+				if tr.Meta.SampleSize > 0 {
+					ss[ssNextWriteIdx] = tr.Meta.SampleSize
+
+					// advance write pointer forward
+					ssNextWriteIdx = (ssNextWriteIdx + 1) % ssSize
+				}
+
+				continue
+			}
+
+			if mr.intervalID.Before(tr.Meta.IntervalID) {
+				mr.intervalID = tr.Meta.IntervalID
+				mr.numIntervalTasks = tr.Meta.NumIntervalTasks
+				mr.lag = tr.Meta.Lag
+			}
+
+			if mr.minQueueDuration > tr.QueueDuration {
+				mr.minQueueDuration = tr.QueueDuration
+			}
+
+			if mr.minTaskDuration > tr.TaskDuration {
+				mr.minTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxTaskDuration < tr.TaskDuration {
+				mr.maxTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxQueueDuration < tr.QueueDuration {
+				mr.maxQueueDuration = tr.QueueDuration
+			}
+
+			mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
+			mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
+			mr.numPass += int(tr.Passed)
+			mr.numFail += int(tr.Errored)
+			mr.numPanic += int(tr.Panicked)
+
+			mr.numTasks++
+
+			mr.latencies.queue.add(tr.QueueDuration)
+			mr.latencies.task.add(tr.TaskDuration)
+
+			if mr.numTasks >= ss[ssReadIdx] {
+
+				writeRow()
+				mr.reset()
+
+				// advance read pointer forward
+				ssReadIdx = (ssReadIdx + 1) % ssSize
+
+				if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
+					cd.writer.Flush()
+					if err := cd.writer.Error(); err != nil {
+						cd.setErr(err) // sets error state in multiple goroutine safe way
+					}
+					cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				}
 			}
 		}
 	}
 }
 
-func (lt *Loadtest) resultsHandler_retryDisabled_maxTasksNotGTZero_percentileDisabled_varianceEnabled() {
+func (lt *Loadtest) resultsHandler_retryDisabled_maxTasksNotGTZero_percentileDisabled_varianceEnabled() func() {
 
-	cd := &lt.csvData
-	var mr metricRecord_retryDisabled_maxTasksNotGTZero_percentileDisabled_varianceEnabled
-	mr.reset()
+	// construct ring buffer of sample sizes (ss)
+	ssSize := lt.maxLiveSamples
+	ss := make([]int, ssSize)
+	var ssNextWriteIdx int
+	var ssReadIdx int
 
-	var writeRow func()
-	{
-		f := lt.writeOutputCsvRow_retryDisabled_maxTasksNotGTZero_percentileDisabled_varianceEnabled()
-		writeRow = func() {
+	return func() {
+		cd := &lt.csvData
+		var mr metricRecord_retryDisabled_maxTasksNotGTZero_percentileDisabled_varianceEnabled
+		mr.reset()
 
-			f(mr)
-		}
-	}
+		var writeRow func()
+		{
+			f := lt.writeOutputCsvRow_retryDisabled_maxTasksNotGTZero_percentileDisabled_varianceEnabled()
+			writeRow = func() {
 
-	cd.flushDeadline = time.Now().Add(cd.flushInterval)
-
-	for {
-		tr, ok := <-lt.resultsChan
-		if !ok {
-			if cd.writeErr == nil && mr.numTasks > 0 {
-				writeRow()
+				f(mr)
 			}
-			return
 		}
 
-		lt.resultWaitGroup.Done()
+		cd.flushDeadline = time.Now().Add(cd.flushInterval)
 
-		if cd.writeErr != nil {
-			continue
-		}
-
-		if tr.taskResultFlags.isZero() {
-
-			mr.sumLag += tr.Meta.Lag
-
-			continue
-		}
-
-		if mr.intervalID.Before(tr.Meta.IntervalID) {
-			mr.intervalID = tr.Meta.IntervalID
-			mr.numIntervalTasks = tr.Meta.NumIntervalTasks
-			mr.lag = tr.Meta.Lag
-		}
-
-		if mr.minQueueDuration > tr.QueueDuration {
-			mr.minQueueDuration = tr.QueueDuration
-		}
-
-		if mr.minTaskDuration > tr.TaskDuration {
-			mr.minTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxTaskDuration < tr.TaskDuration {
-			mr.maxTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxQueueDuration < tr.QueueDuration {
-			mr.maxQueueDuration = tr.QueueDuration
-		}
-
-		mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
-		mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
-		mr.numPass += int(tr.Passed)
-		mr.numFail += int(tr.Errored)
-		mr.numPanic += int(tr.Panicked)
-
-		mr.numTasks++
-
-		mr.welfords.queue.Update(mr.numTasks, float64(tr.QueueDuration))
-		mr.welfords.task.Update(mr.numTasks, float64(tr.TaskDuration))
-
-		if mr.numTasks >= mr.numIntervalTasks {
-
-			writeRow()
-			mr.reset()
-
-			if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
-				cd.writer.Flush()
-				if err := cd.writer.Error(); err != nil {
-					cd.setErr(err) // sets error state in multiple goroutine safe way
+		for {
+			tr, ok := <-lt.resultsChan
+			if !ok {
+				if cd.writeErr == nil && mr.numTasks > 0 {
+					writeRow()
 				}
-				cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				return
+			}
+
+			lt.resultWaitGroup.Done()
+
+			if cd.writeErr != nil {
+				continue
+			}
+
+			if tr.taskResultFlags.isZero() {
+
+				mr.sumLag += tr.Meta.Lag
+
+				if tr.Meta.SampleSize > 0 {
+					ss[ssNextWriteIdx] = tr.Meta.SampleSize
+
+					// advance write pointer forward
+					ssNextWriteIdx = (ssNextWriteIdx + 1) % ssSize
+				}
+
+				continue
+			}
+
+			if mr.intervalID.Before(tr.Meta.IntervalID) {
+				mr.intervalID = tr.Meta.IntervalID
+				mr.numIntervalTasks = tr.Meta.NumIntervalTasks
+				mr.lag = tr.Meta.Lag
+			}
+
+			if mr.minQueueDuration > tr.QueueDuration {
+				mr.minQueueDuration = tr.QueueDuration
+			}
+
+			if mr.minTaskDuration > tr.TaskDuration {
+				mr.minTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxTaskDuration < tr.TaskDuration {
+				mr.maxTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxQueueDuration < tr.QueueDuration {
+				mr.maxQueueDuration = tr.QueueDuration
+			}
+
+			mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
+			mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
+			mr.numPass += int(tr.Passed)
+			mr.numFail += int(tr.Errored)
+			mr.numPanic += int(tr.Panicked)
+
+			mr.numTasks++
+
+			mr.welfords.queue.Update(mr.numTasks, float64(tr.QueueDuration))
+			mr.welfords.task.Update(mr.numTasks, float64(tr.TaskDuration))
+
+			if mr.numTasks >= ss[ssReadIdx] {
+
+				writeRow()
+				mr.reset()
+
+				// advance read pointer forward
+				ssReadIdx = (ssReadIdx + 1) % ssSize
+
+				if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
+					cd.writer.Flush()
+					if err := cd.writer.Error(); err != nil {
+						cd.setErr(err) // sets error state in multiple goroutine safe way
+					}
+					cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				}
 			}
 		}
 	}
 }
 
-func (lt *Loadtest) resultsHandler_retryDisabled_maxTasksNotGTZero_percentileDisabled_varianceDisabled() {
+func (lt *Loadtest) resultsHandler_retryDisabled_maxTasksNotGTZero_percentileDisabled_varianceDisabled() func() {
 
-	cd := &lt.csvData
-	var mr metricRecord_retryDisabled_maxTasksNotGTZero_percentileDisabled_varianceDisabled
-	mr.reset()
+	// construct ring buffer of sample sizes (ss)
+	ssSize := lt.maxLiveSamples
+	ss := make([]int, ssSize)
+	var ssNextWriteIdx int
+	var ssReadIdx int
 
-	var writeRow func()
-	{
-		f := lt.writeOutputCsvRow_retryDisabled_maxTasksNotGTZero_percentileDisabled_varianceDisabled()
-		writeRow = func() {
+	return func() {
+		cd := &lt.csvData
+		var mr metricRecord_retryDisabled_maxTasksNotGTZero_percentileDisabled_varianceDisabled
+		mr.reset()
 
-			f(mr)
-		}
-	}
+		var writeRow func()
+		{
+			f := lt.writeOutputCsvRow_retryDisabled_maxTasksNotGTZero_percentileDisabled_varianceDisabled()
+			writeRow = func() {
 
-	cd.flushDeadline = time.Now().Add(cd.flushInterval)
-
-	for {
-		tr, ok := <-lt.resultsChan
-		if !ok {
-			if cd.writeErr == nil && mr.numTasks > 0 {
-				writeRow()
+				f(mr)
 			}
-			return
 		}
 
-		lt.resultWaitGroup.Done()
+		cd.flushDeadline = time.Now().Add(cd.flushInterval)
 
-		if cd.writeErr != nil {
-			continue
-		}
-
-		if tr.taskResultFlags.isZero() {
-
-			mr.sumLag += tr.Meta.Lag
-
-			continue
-		}
-
-		if mr.intervalID.Before(tr.Meta.IntervalID) {
-			mr.intervalID = tr.Meta.IntervalID
-			mr.numIntervalTasks = tr.Meta.NumIntervalTasks
-			mr.lag = tr.Meta.Lag
-		}
-
-		if mr.minQueueDuration > tr.QueueDuration {
-			mr.minQueueDuration = tr.QueueDuration
-		}
-
-		if mr.minTaskDuration > tr.TaskDuration {
-			mr.minTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxTaskDuration < tr.TaskDuration {
-			mr.maxTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxQueueDuration < tr.QueueDuration {
-			mr.maxQueueDuration = tr.QueueDuration
-		}
-
-		mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
-		mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
-		mr.numPass += int(tr.Passed)
-		mr.numFail += int(tr.Errored)
-		mr.numPanic += int(tr.Panicked)
-
-		mr.numTasks++
-
-		if mr.numTasks >= mr.numIntervalTasks {
-
-			writeRow()
-			mr.reset()
-
-			if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
-				cd.writer.Flush()
-				if err := cd.writer.Error(); err != nil {
-					cd.setErr(err) // sets error state in multiple goroutine safe way
+		for {
+			tr, ok := <-lt.resultsChan
+			if !ok {
+				if cd.writeErr == nil && mr.numTasks > 0 {
+					writeRow()
 				}
-				cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				return
+			}
+
+			lt.resultWaitGroup.Done()
+
+			if cd.writeErr != nil {
+				continue
+			}
+
+			if tr.taskResultFlags.isZero() {
+
+				mr.sumLag += tr.Meta.Lag
+
+				if tr.Meta.SampleSize > 0 {
+					ss[ssNextWriteIdx] = tr.Meta.SampleSize
+
+					// advance write pointer forward
+					ssNextWriteIdx = (ssNextWriteIdx + 1) % ssSize
+				}
+
+				continue
+			}
+
+			if mr.intervalID.Before(tr.Meta.IntervalID) {
+				mr.intervalID = tr.Meta.IntervalID
+				mr.numIntervalTasks = tr.Meta.NumIntervalTasks
+				mr.lag = tr.Meta.Lag
+			}
+
+			if mr.minQueueDuration > tr.QueueDuration {
+				mr.minQueueDuration = tr.QueueDuration
+			}
+
+			if mr.minTaskDuration > tr.TaskDuration {
+				mr.minTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxTaskDuration < tr.TaskDuration {
+				mr.maxTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxQueueDuration < tr.QueueDuration {
+				mr.maxQueueDuration = tr.QueueDuration
+			}
+
+			mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
+			mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
+			mr.numPass += int(tr.Passed)
+			mr.numFail += int(tr.Errored)
+			mr.numPanic += int(tr.Panicked)
+
+			mr.numTasks++
+
+			if mr.numTasks >= ss[ssReadIdx] {
+
+				writeRow()
+				mr.reset()
+
+				// advance read pointer forward
+				ssReadIdx = (ssReadIdx + 1) % ssSize
+
+				if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
+					cd.writer.Flush()
+					if err := cd.writer.Error(); err != nil {
+						cd.setErr(err) // sets error state in multiple goroutine safe way
+					}
+					cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				}
 			}
 		}
 	}

--- a/loadtester/gen_strategies.go
+++ b/loadtester/gen_strategies.go
@@ -1091,7 +1091,7 @@ func (lt *Loadtest) run_retriesEnabled_maxTasksGTZero_metricsEnabled(ctx context
 					lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
 					lt.resultsChan <- taskResult{
 						Meta: taskMeta{
-							IntervalID: intervalID,
+							// IntervalID: intervalID, // not required unless in a debug context
 							SampleSize: taskBufSize,
 						},
 					}
@@ -1133,8 +1133,8 @@ func (lt *Loadtest) run_retriesEnabled_maxTasksGTZero_metricsEnabled(ctx context
 						lt.resultWaitGroup.Add(1)
 						lt.resultsChan <- taskResult{
 							Meta: taskMeta{
-								IntervalID: intervalID,
-								Lag:        lag,
+								// IntervalID: intervalID, // not required unless in a debug context
+								Lag: lag,
 							},
 						}
 
@@ -1542,7 +1542,7 @@ func (lt *Loadtest) run_retriesEnabled_maxTasksGTZero_metricsEnabled(ctx context
 		lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
 		lt.resultsChan <- taskResult{
 			Meta: taskMeta{
-				IntervalID: intervalID,
+				// IntervalID: intervalID, // not required unless in a debug context
 				SampleSize: taskBufSize,
 			},
 		}
@@ -1588,8 +1588,8 @@ func (lt *Loadtest) run_retriesEnabled_maxTasksGTZero_metricsEnabled(ctx context
 			lt.resultWaitGroup.Add(1)
 			lt.resultsChan <- taskResult{
 				Meta: taskMeta{
-					IntervalID: intervalID,
-					Lag:        lag,
+					// IntervalID: intervalID, // not required unless in a debug context
+					Lag: lag,
 				},
 			}
 
@@ -1864,7 +1864,7 @@ func (lt *Loadtest) run_retriesEnabled_maxTasksGTZero_metricsDisabled(ctx contex
 					lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
 					lt.resultsChan <- taskResult{
 						Meta: taskMeta{
-							IntervalID: intervalID,
+							// IntervalID: intervalID, // not required unless in a debug context
 							SampleSize: taskBufSize,
 						},
 					}
@@ -2289,7 +2289,7 @@ func (lt *Loadtest) run_retriesEnabled_maxTasksGTZero_metricsDisabled(ctx contex
 		lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
 		lt.resultsChan <- taskResult{
 			Meta: taskMeta{
-				IntervalID: intervalID,
+				// IntervalID: intervalID, // not required unless in a debug context
 				SampleSize: taskBufSize,
 			},
 		}
@@ -2589,7 +2589,7 @@ func (lt *Loadtest) run_retriesEnabled_maxTasksNotGTZero_metricsEnabled(ctx cont
 					lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
 					lt.resultsChan <- taskResult{
 						Meta: taskMeta{
-							IntervalID: intervalID,
+							// IntervalID: intervalID, // not required unless in a debug context
 							SampleSize: taskBufSize,
 						},
 					}
@@ -2631,8 +2631,8 @@ func (lt *Loadtest) run_retriesEnabled_maxTasksNotGTZero_metricsEnabled(ctx cont
 						lt.resultWaitGroup.Add(1)
 						lt.resultsChan <- taskResult{
 							Meta: taskMeta{
-								IntervalID: intervalID,
-								Lag:        lag,
+								// IntervalID: intervalID, // not required unless in a debug context
+								Lag: lag,
 							},
 						}
 
@@ -3025,7 +3025,7 @@ func (lt *Loadtest) run_retriesEnabled_maxTasksNotGTZero_metricsEnabled(ctx cont
 		lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
 		lt.resultsChan <- taskResult{
 			Meta: taskMeta{
-				IntervalID: intervalID,
+				// IntervalID: intervalID, // not required unless in a debug context
 				SampleSize: taskBufSize,
 			},
 		}
@@ -3071,8 +3071,8 @@ func (lt *Loadtest) run_retriesEnabled_maxTasksNotGTZero_metricsEnabled(ctx cont
 			lt.resultWaitGroup.Add(1)
 			lt.resultsChan <- taskResult{
 				Meta: taskMeta{
-					IntervalID: intervalID,
-					Lag:        lag,
+					// IntervalID: intervalID, // not required unless in a debug context
+					Lag: lag,
 				},
 			}
 
@@ -3309,7 +3309,7 @@ func (lt *Loadtest) run_retriesEnabled_maxTasksNotGTZero_metricsDisabled(ctx con
 					lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
 					lt.resultsChan <- taskResult{
 						Meta: taskMeta{
-							IntervalID: intervalID,
+							// IntervalID: intervalID, // not required unless in a debug context
 							SampleSize: taskBufSize,
 						},
 					}
@@ -3719,7 +3719,7 @@ func (lt *Loadtest) run_retriesEnabled_maxTasksNotGTZero_metricsDisabled(ctx con
 		lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
 		lt.resultsChan <- taskResult{
 			Meta: taskMeta{
-				IntervalID: intervalID,
+				// IntervalID: intervalID, // not required unless in a debug context
 				SampleSize: taskBufSize,
 			},
 		}
@@ -4212,7 +4212,7 @@ func (lt *Loadtest) run_retriesDisabled_maxTasksGTZero_metricsEnabled(ctx contex
 		lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
 		lt.resultsChan <- taskResult{
 			Meta: taskMeta{
-				IntervalID: intervalID,
+				// IntervalID: intervalID, // not required unless in a debug context
 				SampleSize: taskBufSize,
 			},
 		}
@@ -4258,8 +4258,8 @@ func (lt *Loadtest) run_retriesDisabled_maxTasksGTZero_metricsEnabled(ctx contex
 			lt.resultWaitGroup.Add(1)
 			lt.resultsChan <- taskResult{
 				Meta: taskMeta{
-					IntervalID: intervalID,
-					Lag:        lag,
+					// IntervalID: intervalID, // not required unless in a debug context
+					Lag: lag,
 				},
 			}
 
@@ -4677,7 +4677,7 @@ func (lt *Loadtest) run_retriesDisabled_maxTasksGTZero_metricsDisabled(ctx conte
 		lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
 		lt.resultsChan <- taskResult{
 			Meta: taskMeta{
-				IntervalID: intervalID,
+				// IntervalID: intervalID, // not required unless in a debug context
 				SampleSize: taskBufSize,
 			},
 		}
@@ -5153,7 +5153,7 @@ func (lt *Loadtest) run_retriesDisabled_maxTasksNotGTZero_metricsEnabled(ctx con
 		lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
 		lt.resultsChan <- taskResult{
 			Meta: taskMeta{
-				IntervalID: intervalID,
+				// IntervalID: intervalID, // not required unless in a debug context
 				SampleSize: taskBufSize,
 			},
 		}
@@ -5199,8 +5199,8 @@ func (lt *Loadtest) run_retriesDisabled_maxTasksNotGTZero_metricsEnabled(ctx con
 			lt.resultWaitGroup.Add(1)
 			lt.resultsChan <- taskResult{
 				Meta: taskMeta{
-					IntervalID: intervalID,
-					Lag:        lag,
+					// IntervalID: intervalID, // not required unless in a debug context
+					Lag: lag,
 				},
 			}
 
@@ -5601,7 +5601,7 @@ func (lt *Loadtest) run_retriesDisabled_maxTasksNotGTZero_metricsDisabled(ctx co
 		lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
 		lt.resultsChan <- taskResult{
 			Meta: taskMeta{
-				IntervalID: intervalID,
+				// IntervalID: intervalID, // not required unless in a debug context
 				SampleSize: taskBufSize,
 			},
 		}

--- a/loadtester/internal/cmd/generate/resultsHandler.go.tmpl
+++ b/loadtester/internal/cmd/generate/resultsHandler.go.tmpl
@@ -1,97 +1,115 @@
-func (lt *Loadtest) resultsHandler_retry{{if .RetriesEnabled}}Enabled{{else}}Disabled{{end}}_maxTasks{{if not .MaxTasksGTZero}}Not{{end}}GTZero_percentile{{if .PercentileEnabled}}Enabled{{else}}Disabled{{end}}_variance{{if .VarianceEnabled}}Enabled{{else}}Disabled{{end}}() {
+func (lt *Loadtest) resultsHandler_retry{{if .RetriesEnabled}}Enabled{{else}}Disabled{{end}}_maxTasks{{if not .MaxTasksGTZero}}Not{{end}}GTZero_percentile{{if .PercentileEnabled}}Enabled{{else}}Disabled{{end}}_variance{{if .VarianceEnabled}}Enabled{{else}}Disabled{{end}}() func() {
 
-	cd := &lt.csvData
-	var mr metricRecord_retry{{if .RetriesEnabled}}Enabled{{else}}Disabled{{end}}_maxTasks{{if not .MaxTasksGTZero}}Not{{end}}GTZero_percentile{{if .PercentileEnabled}}Enabled{{else}}Disabled{{end}}_variance{{if .VarianceEnabled}}Enabled{{else}}Disabled{{end}}
-	{{if .PercentileEnabled}}mr.latencies = lt.latencies
-	{{end}}mr.reset()
+	// construct ring buffer of sample sizes (ss)
+	ssSize := lt.maxLiveSamples
+	ss := make([]int, ssSize)
+	var ssNextWriteIdx int
+	var ssReadIdx int
 
-	var writeRow func()
-	{
-		f := lt.writeOutputCsvRow_retry{{if .RetriesEnabled}}Enabled{{else}}Disabled{{end}}_maxTasks{{if not .MaxTasksGTZero}}Not{{end}}GTZero_percentile{{if .PercentileEnabled}}Enabled{{else}}Disabled{{end}}_variance{{if .VarianceEnabled}}Enabled{{else}}Disabled{{end}}()
-		writeRow = func() {
-			{{if .MaxTasksGTZero}}
-			mr.totalNumTasks += mr.numTasks
-			{{end}}
-			f(mr)
-		}
-	}
+	return func() {
+		cd := &lt.csvData
+		var mr metricRecord_retry{{if .RetriesEnabled}}Enabled{{else}}Disabled{{end}}_maxTasks{{if not .MaxTasksGTZero}}Not{{end}}GTZero_percentile{{if .PercentileEnabled}}Enabled{{else}}Disabled{{end}}_variance{{if .VarianceEnabled}}Enabled{{else}}Disabled{{end}}
+		{{if .PercentileEnabled}}mr.latencies = lt.latencies
+		{{end}}mr.reset()
 
-	cd.flushDeadline = time.Now().Add(cd.flushInterval)
-
-	for {
-		tr, ok := <-lt.resultsChan
-		if !ok {
-			if cd.writeErr == nil && mr.numTasks > 0 {
-				writeRow()
+		var writeRow func()
+		{
+			f := lt.writeOutputCsvRow_retry{{if .RetriesEnabled}}Enabled{{else}}Disabled{{end}}_maxTasks{{if not .MaxTasksGTZero}}Not{{end}}GTZero_percentile{{if .PercentileEnabled}}Enabled{{else}}Disabled{{end}}_variance{{if .VarianceEnabled}}Enabled{{else}}Disabled{{end}}()
+			writeRow = func() {
+				{{if .MaxTasksGTZero}}
+				mr.totalNumTasks += mr.numTasks
+				{{end}}
+				f(mr)
 			}
-			return
 		}
 
-		lt.resultWaitGroup.Done()
+		cd.flushDeadline = time.Now().Add(cd.flushInterval)
 
-		if cd.writeErr != nil {
-			continue
-		}
-
-		if tr.taskResultFlags.isZero() {
-
-			mr.sumLag += tr.Meta.Lag
-
-			continue
-		}
-
-		if mr.intervalID.Before(tr.Meta.IntervalID) {
-			mr.intervalID = tr.Meta.IntervalID
-			mr.numIntervalTasks = tr.Meta.NumIntervalTasks
-			mr.lag = tr.Meta.Lag
-		}
-
-		if mr.minQueueDuration > tr.QueueDuration {
-			mr.minQueueDuration = tr.QueueDuration
-		}
-
-		if mr.minTaskDuration > tr.TaskDuration {
-			mr.minTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxTaskDuration < tr.TaskDuration {
-			mr.maxTaskDuration = tr.TaskDuration
-		}
-
-		if mr.maxQueueDuration < tr.QueueDuration {
-			mr.maxQueueDuration = tr.QueueDuration
-		}
-
-		mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
-		mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
-		mr.numPass += int(tr.Passed)
-		mr.numFail += int(tr.Errored)
-		mr.numPanic += int(tr.Panicked){{if .RetriesEnabled}}
-		mr.numRetry += int(tr.RetryQueued){{end}}
-
-		mr.numTasks++
-
-		{{if .VarianceEnabled}}
-		mr.welfords.queue.Update(mr.numTasks, float64(tr.QueueDuration))
-		mr.welfords.task.Update(mr.numTasks, float64(tr.TaskDuration))
-		{{end}}
-
-		{{if .PercentileEnabled -}}
-		mr.latencies.queue.add(tr.QueueDuration)
-		mr.latencies.task.add(tr.TaskDuration)
-		{{end}}
-
-		if mr.numTasks >= mr.numIntervalTasks {
-
-			writeRow()
-			mr.reset()
-
-			if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
-				cd.writer.Flush()
-				if err := cd.writer.Error(); err != nil {
-					cd.setErr(err) // sets error state in multiple goroutine safe way
+		for {
+			tr, ok := <-lt.resultsChan
+			if !ok {
+				if cd.writeErr == nil && mr.numTasks > 0 {
+					writeRow()
 				}
-				cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				return
+			}
+
+			lt.resultWaitGroup.Done()
+
+			if cd.writeErr != nil {
+				continue
+			}
+
+			if tr.taskResultFlags.isZero() {
+
+				mr.sumLag += tr.Meta.Lag
+
+				if tr.Meta.SampleSize > 0 {
+					ss[ssNextWriteIdx] = tr.Meta.SampleSize
+
+					// advance write pointer forward
+					ssNextWriteIdx = (ssNextWriteIdx + 1) % ssSize
+				}
+
+				continue
+			}
+
+			if mr.intervalID.Before(tr.Meta.IntervalID) {
+				mr.intervalID = tr.Meta.IntervalID
+				mr.numIntervalTasks = tr.Meta.NumIntervalTasks
+				mr.lag = tr.Meta.Lag
+			}
+
+			if mr.minQueueDuration > tr.QueueDuration {
+				mr.minQueueDuration = tr.QueueDuration
+			}
+
+			if mr.minTaskDuration > tr.TaskDuration {
+				mr.minTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxTaskDuration < tr.TaskDuration {
+				mr.maxTaskDuration = tr.TaskDuration
+			}
+
+			if mr.maxQueueDuration < tr.QueueDuration {
+				mr.maxQueueDuration = tr.QueueDuration
+			}
+
+			mr.sumQueueDuration.Add(&mr.sumQueueDuration, big.NewInt(int64(tr.QueueDuration)))
+			mr.sumTaskDuration.Add(&mr.sumTaskDuration, big.NewInt(int64(tr.TaskDuration)))
+			mr.numPass += int(tr.Passed)
+			mr.numFail += int(tr.Errored)
+			mr.numPanic += int(tr.Panicked){{if .RetriesEnabled}}
+			mr.numRetry += int(tr.RetryQueued){{end}}
+
+			mr.numTasks++
+
+			{{if .VarianceEnabled}}
+			mr.welfords.queue.Update(mr.numTasks, float64(tr.QueueDuration))
+			mr.welfords.task.Update(mr.numTasks, float64(tr.TaskDuration))
+			{{end}}
+
+			{{if .PercentileEnabled -}}
+			mr.latencies.queue.add(tr.QueueDuration)
+			mr.latencies.task.add(tr.TaskDuration)
+			{{end}}
+
+			if mr.numTasks >= ss[ssReadIdx] {
+
+				writeRow()
+				mr.reset()
+
+				// advance read pointer forward
+				ssReadIdx = (ssReadIdx + 1) % ssSize
+
+				if cd.writeErr == nil && !cd.flushDeadline.After(time.Now()) {
+					cd.writer.Flush()
+					if err := cd.writer.Error(); err != nil {
+						cd.setErr(err) // sets error state in multiple goroutine safe way
+					}
+					cd.flushDeadline = time.Now().Add(cd.flushInterval)
+				}
 			}
 		}
 	}

--- a/loadtester/internal/cmd/generate/run.go.tmpl
+++ b/loadtester/internal/cmd/generate/run.go.tmpl
@@ -301,7 +301,13 @@ func (lt *Loadtest) run_retries{{if .RetriesEnabled}}Enabled{{else}}Disabled{{en
 						lt.intervalTasksSema.Release(int64(numNewTasks - taskBufSize))
 					}
 
-					lt.resultWaitGroup.Add(taskBufSize)
+					lt.resultWaitGroup.Add(taskBufSize+1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
+					lt.resultsChan <- taskResult{
+						Meta: taskMeta{
+							IntervalID: intervalID,
+							SampleSize: taskBufSize,
+						},
+					}
 
 					meta.IntervalID = intervalID
 
@@ -771,7 +777,13 @@ func (lt *Loadtest) run_retries{{if .RetriesEnabled}}Enabled{{else}}Disabled{{en
 		}
 		{{end}}
 
-		lt.resultWaitGroup.Add(taskBufSize)
+		lt.resultWaitGroup.Add(taskBufSize+1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
+		lt.resultsChan <- taskResult{
+			Meta: taskMeta{
+				IntervalID: intervalID,
+				SampleSize: taskBufSize,
+			},
+		}
 
 		meta.IntervalID = intervalID
 

--- a/loadtester/internal/cmd/generate/run.go.tmpl
+++ b/loadtester/internal/cmd/generate/run.go.tmpl
@@ -304,7 +304,7 @@ func (lt *Loadtest) run_retries{{if .RetriesEnabled}}Enabled{{else}}Disabled{{en
 					lt.resultWaitGroup.Add(taskBufSize+1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
 					lt.resultsChan <- taskResult{
 						Meta: taskMeta{
-							IntervalID: intervalID,
+							// IntervalID: intervalID, // not required unless in a debug context
 							SampleSize: taskBufSize,
 						},
 					}
@@ -347,7 +347,7 @@ func (lt *Loadtest) run_retries{{if .RetriesEnabled}}Enabled{{else}}Disabled{{en
 						lt.resultWaitGroup.Add(1)
 						lt.resultsChan <- taskResult{
 							Meta: taskMeta{
-								IntervalID: intervalID,
+								// IntervalID: intervalID, // not required unless in a debug context
 								Lag:        lag,
 							},
 						}
@@ -780,7 +780,7 @@ func (lt *Loadtest) run_retries{{if .RetriesEnabled}}Enabled{{else}}Disabled{{en
 		lt.resultWaitGroup.Add(taskBufSize+1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
 		lt.resultsChan <- taskResult{
 			Meta: taskMeta{
-				IntervalID: intervalID,
+				// IntervalID: intervalID, // not required unless in a debug context
 				SampleSize: taskBufSize,
 			},
 		}
@@ -827,7 +827,7 @@ func (lt *Loadtest) run_retries{{if .RetriesEnabled}}Enabled{{else}}Disabled{{en
 			lt.resultWaitGroup.Add(1)
 			lt.resultsChan <- taskResult{
 				Meta: taskMeta{
-					IntervalID: intervalID,
+					// IntervalID: intervalID, // not required unless in a debug context
 					Lag:        lag,
 				},
 			}

--- a/loadtester/loadtest_options.go
+++ b/loadtester/loadtest_options.go
@@ -120,12 +120,13 @@ func newLoadtestConfig(options ...LoadtestOption) (loadtestConfig, error) {
 	// check for integer overflows from user input when computing metrics
 	if cfg.csvOutputEnabled {
 		const intervalPossibleLagResultCount = 1
+		const intervalSampleSizeResultCount = 1
 		// note: if intervalPossibleLagResultCount is ever adjusted, then the bellow if statement needs to change
-		if cfg.maxIntervalTasks == math.MaxInt {
+		if cfg.maxIntervalTasks > (math.MaxInt - intervalPossibleLagResultCount - intervalSampleSizeResultCount) {
 			return result, errors.New("MaxIntervalTasks value is too large")
 		}
 
-		maxIntervalResultCount := cfg.maxIntervalTasks + intervalPossibleLagResultCount
+		maxIntervalResultCount := cfg.maxIntervalTasks + intervalPossibleLagResultCount + intervalSampleSizeResultCount
 		if maxIntervalResultCount > (math.MaxInt / cfg.outputBufferingFactor) {
 			return result, errors.New("MaxIntervalTasks and OutputBufferingFactor values combination is too large")
 		}

--- a/loadtester/task.go
+++ b/loadtester/task.go
@@ -58,6 +58,8 @@ func (rt *retryTask) Do(ctx context.Context, workerID int) error {
 type taskMeta struct {
 	IntervalID time.Time
 
+	SampleSize int
+
 	//
 	// rate gauges:
 	//


### PR DESCRIPTION
with the enqueue intent/reality.

When adjusting the interval task size over time there has been a known indeterminate behavior. If the user defined configuration manager of the runner is interested in adjusting task count per interval from 3, to 9, to 27 the metrics reports may go from reporting groups of 3 to groups of 27 and skip over one or more groups of the middle task count intent size (9).

This change adjusts the logic to be 1-1 or 100% deterministic with load generation task count blocks without sacrificing much efficiency on reporting statistics per interval given existing back-pressure logic.

This is achieved by using a single slice of ints in a circular buffer fashion that takes constant time to read and write. Overflows of this buffer are not possible given other assurances that exist in the code.