### PR TITLE
upgrade to v5 and remove ns suffix from variance values

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -39,8 +39,8 @@ The output CSV file has the following metric possibilities:
 | p99_task_latency | RFC3339Nano Time String \| empty string | 99% of all metric records in the sample interval have an execution phase latency at or under this value. It will be an empty string if there are no records in the sample interval. Only present in output file when the MetricsLatencyPercentile() option is set to true ( default value: false) |
 | p99p9_task_latency | RFC3339Nano Time String \| empty string | 99.90% of all metric records in the sample interval have an execution phase latency at or under this value. It will be an empty string if there are no records in the sample interval. Only present in output file when the MetricsLatencyPercentile() option is set to true ( default value: false) |
 | p99p99_task_latency | RFC3339Nano Time String \| empty string | 99.99% of all metric records in the sample interval have an execution phase latency at or under this value. It will be an empty string if there are no records in the sample interval. Only present in output file when the MetricsLatencyPercentile() option is set to true ( default value: false) |
-| queue_latency_variance | Duration String \| empty string | The welford variance value computed for the queue phase of tasks completed in the sample interval. Always output in nanoseconds. Will be set to an empty string if the sample size for the interval is less than two. Only present in output file when the MetricsLatencyVariance() option is set to true ( default value: false) |
-| task_latency_variance | Duration String \| empty string | The welford variance value computed for the execution phase of tasks completed in the sample interval. Always output in nanoseconds. Will be set to an empty string if the sample size for the interval is less than two. Only present in output file when the MetricsLatencyVariance() option is set to true ( default value: false) |
+| queue_latency_variance | Duration String \| empty string | The welford variance value computed for the queue phase of tasks completed in the sample interval. Always output in nanoseconds squared. No unit indicator will be at the end of the integer value. Will be set to an empty string if the sample size for the interval is less than two. Only present in output file when the MetricsLatencyVariance() option is set to true ( default value: false) |
+| task_latency_variance | Duration String \| empty string | The welford variance value computed for the execution phase of tasks completed in the sample interval. Always output in nanoseconds squared. No unit indicator will be at the end of the integer value. Will be set to an empty string if the sample size for the interval is less than two. Only present in output file when the MetricsLatencyVariance() option is set to true ( default value: false) |
 | percent_done | Double | A numeric value with precision to the second decimal place ranging from 0 to 100. Only present in output file when the MaxTasks() option is set to a value greater than zero ( default value: 0) |
 
 # changelog
@@ -51,6 +51,8 @@ In version 2.x of this "library" sums of queued and execution durations for all 
 
 | version | metric                 | change             |
 | ------- | ---------------------- | ------------------ |
+| 5.x     | queue_latency_variance | :wavy_dash: format |
+| 5.x     | task_latency_variance  | :wavy_dash: format |
 | 3.x     | p25_queue_latency      | :heavy_plus_sign:  |
 | 3.x     | p50_queue_latency      | :heavy_plus_sign:  |
 | 3.x     | p75_queue_latency      | :heavy_plus_sign:  |

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/josephcopenhaver/loadtester-go/v3
+module github.com/josephcopenhaver/loadtester-go/v5
 
 go 1.21
 

--- a/loadtester/example/main.go
+++ b/loadtester/example/main.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/josephcopenhaver/loadtester-go/v3/loadtester"
+	"github.com/josephcopenhaver/loadtester-go/v5/loadtester"
 )
 
 type task struct{}

--- a/loadtester/example_http/main.go
+++ b/loadtester/example_http/main.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/josephcopenhaver/loadtester-go/v3/loadtester"
+	"github.com/josephcopenhaver/loadtester-go/v5/loadtester"
 )
 
 type task struct {

--- a/loadtester/variance.go
+++ b/loadtester/variance.go
@@ -42,6 +42,10 @@ func (wv *welfordVariance) Variance(count int) float64 {
 // 	return wv.m2 / (float64(count) - float64(1.0))
 // }
 
+// varianceFloatString takes a zero or greater than zero or NaN float value representing welford variance of a sample of floats
+// and returns a "unit-squared" representation integer as a string
+//
+// Note that if you copy this function it really should panic if the input is negative. Variance cannot be negative!
 func varianceFloatString(f float64) string {
 	if math.IsNaN(f) {
 		return ""
@@ -49,8 +53,8 @@ func varianceFloatString(f float64) string {
 
 	v := int64(math.MaxInt64)
 	if !math.IsInf(f, 1) {
-		v = int64(math.Round(f)) & math.MaxInt64
+		v = int64(math.Round(f))
 	}
 
-	return strconv.FormatInt(v, 10) + "ns"
+	return strconv.FormatInt(v, 10)
 }


### PR DESCRIPTION
Forgot to bump the module version to v4; so just gonna skip it and move forward.