### PR TITLE
fix report card link versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # loadtester-go
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/josephcopenhaver/loadtester-go)](https://goreportcard.com/report/github.com/josephcopenhaver/loadtester-go)
+[![Go Report Card](https://goreportcard.com/badge/github.com/josephcopenhaver/loadtester-go/v5)](https://goreportcard.com/report/github.com/josephcopenhaver/loadtester-go/v5)
 
 ---
 


### PR DESCRIPTION
Turns out the links default to the latest major version up and including v1.

Found this when I went from the report card to the source when I opened https://github.com/josephcopenhaver/loadtester-go/issues/29 Certainly a trivial thing to adjust.