### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ For information on what metrics are included by this "framework" without bringin
 
 ---
 
-[![Go Documentation](https://godocs.io/github.com/josephcopenhaver/loadtester-go/v5?status.svg)](https://godocs.io/github.com/josephcopenhaver/loadtester-go/v5/loadtester)
+[![Go Reference](https://pkg.go.dev/badge/github.com/josephcopenhaver/loadtester-go/v5/loadtester)](https://pkg.go.dev/github.com/josephcopenhaver/loadtester-go/v5/loadtester)


### PR DESCRIPTION
Moving docs link to pkg.go.dev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the Go documentation badge in the README to use pkg.go.dev instead of godocs.io.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->