### PR TITLE
bugfix: float fallback was missing a line to refresh a value

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -55,6 +55,8 @@ In version 2.x of this "library" sums of queued and execution durations for all 
 
 | version | metric                 | change             |
 | ------- | ---------------------- | ------------------ |
+| 5.0.5   | p*_queue_latency       | :wavy_dash: BUGFIX: very high throughput configurations could lead to duplicate incorrect values being reported |
+| 5.0.5   | p*_task_latency        | :wavy_dash: BUGFIX: very high throughput configurations could lead to duplicate incorrect values being reported |
 | 5.x     | sample_time            | :wavy_dash: format |
 | 5.x     | interval_id            | :wavy_dash: format |
 | 5.x     | sum_lag                | :wavy_dash: format |

--- a/loadtester/latencylist.go
+++ b/loadtester/latencylist.go
@@ -35,7 +35,7 @@ func newPTarget(percentileTimes100, n, d int) percentileTarget {
 const numPercentiles = 10
 
 var percentileTargets = [numPercentiles]percentileTarget{
-	newPTarget(2500, 1, 4), // 0
+	newPTarget(2500, 1, 4), // 0 (percentile target index)
 	newPTarget(5000, 1, 2), // 1
 	newPTarget(7500, 3, 4), // 2
 	// next val's n & d are intentionally doubled so last argument (d) can be even for integer rounding term ( d/2 )
@@ -49,7 +49,7 @@ var percentileTargets = [numPercentiles]percentileTarget{
 }
 
 var percentileComputeOrder = [numPercentiles]uint8{
-	0, // 1
+	0, // 1 (numerator value: which should never decrease)
 	1, // 1
 	2, // 3
 	3, // 8
@@ -95,6 +95,12 @@ func (ll *latencyList) readPercentileStrings(out *[numPercentiles]string) {
 		}
 
 		// would overflow, time to use expensive floats
+		//
+		// this inner loop will finish populating the remaining cells
+		// and the parent loop will never be entered into again
+		//
+		// consider this a terminal return block that happens to be a loop
+		// as well
 		for {
 			fidx := math.Round(float64(pt.n) / float64(pt.d) * float64(maxIdx))
 
@@ -108,6 +114,7 @@ func (ll *latencyList) readPercentileStrings(out *[numPercentiles]string) {
 			}
 
 			pcv = percentileComputeOrder[pci]
+			pt = percentileTargets[pcv]
 		}
 	}
 }


### PR DESCRIPTION
This is a data reporting bugfix.

It would only be encountered when dealing with very high throughput configurations. Both sets of percentile latency type metrics could be impacted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected percentile calculations when computing multiple percentiles, ensuring accurate latency metrics and preventing stale target data from affecting subsequent percentile results.
  * Stabilized latency index computations to avoid inconsistencies under high-throughput or varied load scenarios.

* **Documentation**
  * Added changelog entries noting fixes for duplicate/incorrect queue and task latency values in very high throughput configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->