### PR TITLE
bugfix: GetTaskMetadataProvider was panicing rather than returning nil

### DIFF
--- a/loadtester/task_metadata.go
+++ b/loadtester/task_metadata.go
@@ -75,5 +75,9 @@ func injectTaskMetadataProvider(ctx context.Context, tm *taskMetadata) context.C
 //
 // - `Lag() time.Duration`
 func GetTaskMetadataProvider(ctx context.Context) *taskMetadata {
-	return ctx.Value(taskMetadataCtxKey{}).(*taskMetadata)
+	if v, ok := ctx.Value(taskMetadataCtxKey{}).(*taskMetadata); ok {
+		return v
+	}
+
+	return nil
 }

--- a/loadtester/task_metadata_test.go
+++ b/loadtester/task_metadata_test.go
@@ -1,6 +1,7 @@
 package loadtester
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -48,6 +49,12 @@ func TestMetadataProviderInterfaceStability(t *testing.T) {
 	}
 
 	if v.Lag() != 2*time.Second {
+		t.Fatal()
+	}
+}
+
+func TestMetadataProviderNilable(t *testing.T) {
+	if v := GetTaskMetadataProvider(context.Background()); v != nil {
 		t.Fatal()
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for context value retrieval to gracefully manage missing or invalid values instead of causing crashes.

* **Tests**
  * Added test coverage to verify proper behavior when context values are absent or malformed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->