### PR TITLE
fix deadlock when metrics are disabled

### DIFF
--- a/loadtester/example/main.go
+++ b/loadtester/example/main.go
@@ -78,9 +78,9 @@ func main() {
 		op.Interval(1*time.Second),
 		op.Retry(false), // default is true; not required for this example since no tasks can be retried, plus saves some minor compute and disk io
 		// op.MetricsLatencyPercentile(true), // default is false
-		// op.MetricsLatencyVarianceEnabled(true),    // default is false
+		// op.MetricsLatencyVariance(true), // default is false
 		// op.FlushRetriesOnShutdown(true), // default is false
-		// op.MetricsCsv(false) // default is true; set to false to stop creating a metrics.csv file on loadtest run
+		// op.MetricsCsv(false), // default is true; set to false to stop creating a metrics.csv file on loadtest run
 	)
 	if err != nil {
 		panic(err)

--- a/loadtester/example_http/main.go
+++ b/loadtester/example_http/main.go
@@ -147,9 +147,9 @@ func main() {
 		op.Interval(5*time.Second),
 		op.Retry(false), // default is true; not required for this example since no tasks can be retried, plus saves some minor compute and disk io
 		// op.MetricsLatencyPercentile(true), // default is false
-		// op.MetricsLatencyVarianceEnabled(true),    // default is false
+		// op.MetricsLatencyVariance(true), // default is false
 		// op.FlushRetriesOnShutdown(true), // default is false
-		// op.MetricsCsv(false) // default is true; set to false to stop creating a metrics.csv file on loadtest run
+		// op.MetricsCsv(false), // default is true; set to false to stop creating a metrics.csv file on loadtest run
 	)
 	if err != nil {
 		panic(err)

--- a/loadtester/gen_strategies.go
+++ b/loadtester/gen_strategies.go
@@ -2266,13 +2266,7 @@ func (lt *Loadtest) run_retriesEnabled_maxTasksGTZero_metricsDisabled(ctx contex
 						lt.intervalTasksSema.Release(int64(numNewTasks - taskBufSize))
 					}
 
-					lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
-					lt.resultsChan <- taskResult{
-						Meta: taskMeta{
-							// IntervalID: intervalID, // not required unless in a debug context
-							SampleSize: taskBufSize,
-						},
-					}
+					lt.resultWaitGroup.Add(taskBufSize)
 
 					meta.IntervalID = intervalID
 
@@ -2691,13 +2685,7 @@ func (lt *Loadtest) run_retriesEnabled_maxTasksGTZero_metricsDisabled(ctx contex
 			lt.intervalTasksSema.Release(int64(numNewTasks - taskBufSize))
 		}
 
-		lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
-		lt.resultsChan <- taskResult{
-			Meta: taskMeta{
-				// IntervalID: intervalID, // not required unless in a debug context
-				SampleSize: taskBufSize,
-			},
-		}
+		lt.resultWaitGroup.Add(taskBufSize)
 
 		meta.IntervalID = intervalID
 
@@ -3723,13 +3711,7 @@ func (lt *Loadtest) run_retriesEnabled_maxTasksNotGTZero_metricsDisabled(ctx con
 						lt.intervalTasksSema.Release(int64(numNewTasks - taskBufSize))
 					}
 
-					lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
-					lt.resultsChan <- taskResult{
-						Meta: taskMeta{
-							// IntervalID: intervalID, // not required unless in a debug context
-							SampleSize: taskBufSize,
-						},
-					}
+					lt.resultWaitGroup.Add(taskBufSize)
 
 					meta.IntervalID = intervalID
 
@@ -4136,13 +4118,7 @@ func (lt *Loadtest) run_retriesEnabled_maxTasksNotGTZero_metricsDisabled(ctx con
 			lt.intervalTasksSema.Release(int64(numNewTasks - taskBufSize))
 		}
 
-		lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
-		lt.resultsChan <- taskResult{
-			Meta: taskMeta{
-				// IntervalID: intervalID, // not required unless in a debug context
-				SampleSize: taskBufSize,
-			},
-		}
+		lt.resultWaitGroup.Add(taskBufSize)
 
 		meta.IntervalID = intervalID
 
@@ -5103,13 +5079,7 @@ func (lt *Loadtest) run_retriesDisabled_maxTasksGTZero_metricsDisabled(ctx conte
 			return nil
 		}
 
-		lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
-		lt.resultsChan <- taskResult{
-			Meta: taskMeta{
-				// IntervalID: intervalID, // not required unless in a debug context
-				SampleSize: taskBufSize,
-			},
-		}
+		lt.resultWaitGroup.Add(taskBufSize)
 
 		meta.IntervalID = intervalID
 
@@ -6042,13 +6012,7 @@ func (lt *Loadtest) run_retriesDisabled_maxTasksNotGTZero_metricsDisabled(ctx co
 			return nil
 		}
 
-		lt.resultWaitGroup.Add(taskBufSize + 1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
-		lt.resultsChan <- taskResult{
-			Meta: taskMeta{
-				// IntervalID: intervalID, // not required unless in a debug context
-				SampleSize: taskBufSize,
-			},
-		}
+		lt.resultWaitGroup.Add(taskBufSize)
 
 		meta.IntervalID = intervalID
 

--- a/loadtester/internal/cmd/generate/run.go.tmpl
+++ b/loadtester/internal/cmd/generate/run.go.tmpl
@@ -306,6 +306,7 @@ func (lt *Loadtest) run_retries{{if .RetriesEnabled}}Enabled{{else}}Disabled{{en
 						lt.intervalTasksSema.Release(int64(numNewTasks - taskBufSize))
 					}
 
+					{{if .MetricsEnabled}}
 					lt.resultWaitGroup.Add(taskBufSize+1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
 					lt.resultsChan <- taskResult{
 						Meta: taskMeta{
@@ -313,6 +314,9 @@ func (lt *Loadtest) run_retries{{if .RetriesEnabled}}Enabled{{else}}Disabled{{en
 							SampleSize: taskBufSize,
 						},
 					}
+					{{else}}
+					lt.resultWaitGroup.Add(taskBufSize)
+					{{end}}
 
 					meta.IntervalID = intervalID
 
@@ -780,6 +784,7 @@ func (lt *Loadtest) run_retries{{if .RetriesEnabled}}Enabled{{else}}Disabled{{en
 		}
 		{{end}}
 
+		{{if .MetricsEnabled}}
 		lt.resultWaitGroup.Add(taskBufSize+1) // +1 because we're sending the expected Sample Size immediately to the results handler before queueing tasks
 		lt.resultsChan <- taskResult{
 			Meta: taskMeta{
@@ -787,6 +792,9 @@ func (lt *Loadtest) run_retries{{if .RetriesEnabled}}Enabled{{else}}Disabled{{en
 				SampleSize: taskBufSize,
 			},
 		}
+		{{else}}
+		lt.resultWaitGroup.Add(taskBufSize)
+		{{end}}
 
 		meta.IntervalID = intervalID
 


### PR DESCRIPTION
When metrics are disabled, any send to the resultsChan will block forever because the channel is nil.

This fix simply removes the send action that was added when sample size reporting stabilization was added.

Issue present since:
https://github.com/josephcopenhaver/loadtester-go/pull/17 a.k.a. [v3.0.1](https://github.com/josephcopenhaver/loadtester-go/releases/tag/v3.0.1)

(shows how often that is disabled eh)